### PR TITLE
kola/tests/misc/verity: check arm64 board on all platforms

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/tests/util"
 	"github.com/coreos/mantle/platform"
-	"github.com/coreos/mantle/platform/machine/qemu"
 )
 
 func init() {
@@ -111,8 +110,8 @@ func VerityCorruption(c cluster.TestCluster) {
 
 // get offset of verity hash within kernel
 func getKernelVerityHashOffset(c cluster.TestCluster) int {
-	// assume ARM64 is only on QEMU for now
-	if _, ok := c.Cluster.(*qemu.Cluster); ok && kola.QEMUOptions.Board == "arm64-usr" {
+	// the QEMUOptions.Board is also used by other platforms
+	if kola.QEMUOptions.Board == "arm64-usr" {
 		return 512
 	}
 	return 64


### PR DESCRIPTION
The QEMUOptions.Board value is used for all platform tests and the
preceding check for the QEMU platform made it use the wrong kernel
offset on other platforms.


## How to use

Run the `cl.verity` or the `cl.update.badverity` or `coreos.update.badusr` tests on arm64 machines that are not QEMU (e.g, AWS or Equinix Metal).

## Testing done

None because the polkit failure doesn't let the tests run