### PR TITLE
platform/api/azure: cleanup after Azcopy

### DIFF
--- a/platform/api/azure/storage_mit.go
+++ b/platform/api/azure/storage_mit.go
@@ -352,10 +352,13 @@ func (a *API) CopyBlob(storageaccount, storagekey, container, targetBlob, source
 		if err != nil {
 			return err
 		}
-		cmd := exec.Command(azcopy, "cp", "--blob-type=PageBlob", sourceBlob, dstSas)
+		// log-level=NONE only affects the log file - stdout is unaffected
+		cmd := exec.Command(azcopy, "cp", "--blob-type=PageBlob", "--log-level=NONE", sourceBlob, dstSas)
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		err = cmd.Run()
+		// azcopy leaves behind "plan" files in case a job needs to be retried
+		_ = exec.Command("azcopy", "jobs", "clean").Run()
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
Azcopy unfortunately leaves behind log files and plan files in $HOME/.azcopy.
Passing `--log-level=NONE` removes the log files (but stdout remains informational)
and the plans files are cleaned up after the copy command finishes.

## Testing done

```
$ kola spawn --platform=azure --verbose
2021-08-27T08:24:46Z cli: Started logging at level INFO
2021-08-27T08:24:47Z platform/api/azure: Creating ResourceGroup kola-cluster-image-221f99a0b3
2021-08-27T08:24:48Z platform/api/azure: Creating StorageAccount kolasa41a026327a
2021-08-27T08:25:08Z platform/api/azure: Creating VirtualNetwork kola-vn
2021-08-27T08:25:13Z platform/api/azure: Creating Subnet kola-subnet
2021-08-27T08:25:16Z platform/machine/azure: Copying blob
INFO: Scanning...
INFO: Failed to create one or more destination container(s). Your transfers may still succeed if the container already exists.
INFO: Any empty folders will not be processed, because source and/or destination doesn't have full folder support

Job 5b2f8415-f279-e64e-53e6-2498e41e59c4 has started
Log file is located at: /home/jeremi/.azcopy/5b2f8415-f279-e64e-53e6-2498e41e59c4.log
....
$ ls -laR ~/.azcopy/
/home/jeremi/.azcopy/:
total 12
drwxr-xr-x  3 jeremi jeremi 4096 Aug 27 10:25 .
drwxr-xr-x 30 jeremi jeremi 4096 Aug 27 10:31 ..
drwxr-xr-x  2 jeremi jeremi 4096 Aug 27 10:25 plans

/home/jeremi/.azcopy/plans:
total 8
drwxr-xr-x 2 jeremi jeremi 4096 Aug 27 10:25 .
drwxr-xr-x 3 jeremi jeremi 4096 Aug 27 10:25 ..
```
