### PR TITLE
kola/harness: find right AWS CPU architecture for kolet/skipping tests

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -574,6 +574,9 @@ func architecture(pltfrm string) string {
 	if pltfrm == "packet" && PacketOptions.Board != "" {
 		nativeArch = boardToArch(PacketOptions.Board)
 	}
+	if pltfrm == "aws" && AWSOptions.Board != "" {
+		nativeArch = boardToArch(AWSOptions.Board)
+	}
 	return nativeArch
 }
 


### PR DESCRIPTION
When scpKolet is called it needs to know which board binary to copy.
With the default amd64 we get this error on AWS arm64 instances:
  bash: line 1: ./kolet: cannot execute binary file: Exec format error
The same applies to isAllowed(architecture(platform) which is used to
skip tests that	should only run on amd64, like cl.update.grubnop.

Find the right architecture when running on AWS.

## How to use

Restart Alpha AWS tests to see that these errors are gone:
```
--- FAIL: cl.internet (341.73s)
        cluster.go:75: kolet:
bash: line 1: ./kolet: cannot execute binary file: Exec format error
    --- FAIL: cl.internet/UpdateEngine (0.34s)
            cluster.go:78: kolet: Process exited with status 126
        cluster.go:75: kolet:
bash: line 1: ./kolet: cannot execute binary file: Exec format error
    --- FAIL: cl.internet/DockerPing (0.34s)
            cluster.go:78: kolet: Process exited with status 126
        cluster.go:75: kolet:
bash: line 1: ./kolet: cannot execute binary file: Exec format error
    --- FAIL: cl.internet/DockerEcho (0.33s)
            cluster.go:78: kolet: Process exited with status 126
        cluster.go:75: kolet:
bash: line 1: ./kolet: cannot execute binary file: Exec format error
    --- FAIL: cl.internet/NTPDate (0.34s)
            cluster.go:78: kolet: Process exited with status 126
--- FAIL: cl.basic (341.39s)
        cluster.go:75: kolet:
[…]
```

## Testing done

None