### PR TITLE
cl.filesystem/deadlinks: ignore factory /etc in /usr/share/flatcar/etc

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -91,6 +91,7 @@ func DeadLinks(c cluster.TestCluster) {
 		"/var/lib/docker",
 		"/var/lib/rkt",
 		"/var/lib/flatcar-oem-gce",
+		"/usr/share/flatcar/etc",
 	}
 
 	output := c.MustSSH(m, fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -xtype l -print", strings.Join(ignore, " -prune -o -path ")))


### PR DESCRIPTION
The copy of the factory /etc in /usr/share/flatcar/etc may have dead
links because the relative linking assumes to be under /TOPDIR
(https://github.com/flatcar-linux/scripts/pull/264).
Ignore the folder in the check for dead links, we still check the
resulting /etc hierarchy created based on it.

## How to use

Needed for the linked scripts PR

## Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu/4055/console)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
