### PR TITLE
esx: support initramfs network configuration

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -206,6 +206,10 @@ func FilterTests(tests map[string]*register.Test, patterns []string, channel, of
 	}
 
 	for name, t := range tests {
+		if t.SkipFunc != nil && t.SkipFunc(version, channel, architecture(pltfrm), pltfrm) {
+			continue
+		}
+
 		noMatch := true
 		for _, pattern := range patterns {
 			match, err := filepath.Match(pattern, t.Name)

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -69,6 +69,10 @@ type Test struct {
 	// greater than or equal to EndVersion. This will be ignored if
 	// the name fully matches without globbing.
 	EndVersion semver.Version
+
+	// SkipFunc can be used to define if a test should be skip or not based on some
+	// condition on the version, channel, arch and platform.
+	SkipFunc func(version semver.Version, channel, arch, platform string) bool
 }
 
 // Registered tests live here. Mapping of names to tests.

--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -98,9 +98,6 @@ func init() {
 		Run:     localGadgetTest,
 		Name:    `bpf.local-gadget`,
 		Distros: []string{"cl"},
-		// ESX is excluded because initramfs has no network access
-		// so it's not able to download local-gadget binary.
-		ExcludePlatforms: []string{"esx"},
 		// required while SELinux policy is not correcly updated to support
 		// `bpf` and `perfmon` permission.
 		Flags: []register.Flag{register.NoEnableSelinux},
@@ -109,6 +106,12 @@ func init() {
 		MinVersion: semver.Version{Major: 3033},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (3033) does not have the network-kargs service pulled in:
+			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+			// Let's skip this test for < 3034 on ESX.
+			return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+		},
 	})
 }
 

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	ignition "github.com/flatcar/ignition/config/v2_1/types"
 	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
@@ -30,15 +31,19 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:         dockerTorcxManifestPkgs,
-		ClusterSize: 0,
-		Name:        "docker.torcx-manifest-pkgs",
-		// https://github.com/coreos/bugs/issues/2205 for DO
-		// ESX: Currently Ignition does not support static IPs during the initramfs
-		ExcludePlatforms: []string{"esx", "do"},
+		Run:              dockerTorcxManifestPkgs,
+		ClusterSize:      0,
+		Name:             "docker.torcx-manifest-pkgs",
+		ExcludePlatforms: []string{"do"},
 		Distros:          []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (3033) does not have the network-kargs service pulled in:
+			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+			// Let's skip this test for < 3034 on ESX.
+			return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+		},
 	})
 }
 

--- a/kola/tests/ignition/resource.go
+++ b/kola/tests/ignition/resource.go
@@ -105,19 +105,29 @@ func init() {
 			"Serve": Serve,
 		},
 		// https://github.com/coreos/bugs/issues/2205
-		// ESX: Currently Ignition does not support static IPs during the initramfs
-		ExcludePlatforms: []string{"esx", "do", "qemu-unpriv"},
+		ExcludePlatforms: []string{"do", "qemu-unpriv"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (3033) does not have the network-kargs service pulled in:
+			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+			// Let's skip this test for < 3034 on ESX.
+			return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+		},
 		// This should run on all clouds to test initramfs networking
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.ignition.resource.remote",
 		Run:         resourceRemote,
 		ClusterSize: 1,
-		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// https://github.com/coreos/bugs/issues/2205 for DO
-		ExcludePlatforms: []string{"esx", "do"},
 		// This should run on all clouds to test initramfs networking
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (3033) does not have the network-kargs service pulled in:
+			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+			// Let's skip this test for < 3034 on ESX.
+			return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+		},
+		ExcludePlatforms: []string{"do"},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0"
@@ -237,12 +247,16 @@ func init() {
 	//       this test should be rolled into coreos.ignition.resources.remote
 	// Test specifically for versioned s3 objects
 	register.Register(&register.Test{
-		Name:        "coreos.ignition.resource.s3.versioned",
-		Run:         resourceS3Versioned,
-		ClusterSize: 1,
-		// ESX: Currently Ignition does not support static IPs during the initramfs
-		// https://github.com/coreos/bugs/issues/2205 for DO
-		ExcludePlatforms: []string{"esx", "do"},
+		Name:             "coreos.ignition.resource.s3.versioned",
+		Run:              resourceS3Versioned,
+		ClusterSize:      1,
+		ExcludePlatforms: []string{"do"},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (3033) does not have the network-kargs service pulled in:
+			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+			// Let's skip this test for < 3034 on ESX.
+			return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+		},
 		// This does not need to run on all clouds because it is a special case of coreos.ignition.resource.remote
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 1995},

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -210,14 +210,20 @@ func init() {
 				register.Register(&register.Test{
 					Name:    fmt.Sprintf("kubeadm.%s.%s%s.base", version, CNI, cgroupSuffix),
 					Distros: []string{"cl"},
-					// Network config problems in esx and qemu-unpriv
-					ExcludePlatforms: []string{"esx", "qemu-unpriv"},
 					// This should run on all clouds as a good end-to-end test
+					// Network config problems in qemu-unpriv
+					ExcludePlatforms: []string{"qemu-unpriv"},
 					Run: func(c cluster.TestCluster) {
 						kubeadmBaseTest(c, testParams)
 					},
 					MinVersion: semver.Version{Major: major},
 					Flags:      flags,
+					SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+						// LTS (3033) does not have the network-kargs service pulled in:
+						// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
+						// Let's skip this test for < 3034 on ESX.
+						return version.LessThan(semver.Version{Major: 3034}) && platform == "esx"
+					},
 				})
 			}
 		}

--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -429,6 +429,12 @@ func (a *API) CreateDevice(name string, conf *conf.Conf, ips *IpPair) (*ESXMachi
 	}
 
 	if ips != nil {
+		// based on: https://mirrors.edge.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_network
+		kArgs := fmt.Sprintf("ip=%s::%s:%d::ens192:off:1.1.1.1:1.0.0.1", ips.Public, ips.PublicGw, ips.SubnetSize)
+		if err := a.updateGuestVariable(vm, "guestinfo.afterburn.initrd.network-kargs", kArgs); err != nil {
+			return nil, fmt.Errorf("setting guestinfo variable: %v", err)
+		}
+
 		err = a.updateGuestVariable(vm, "guestinfo.dns.server.0", "1.1.1.1")
 		if err != nil {
 			return nil, fmt.Errorf("setting guestinfo variable: %v", err)


### PR DESCRIPTION
In this PR, we add the `ip` kernel argument following this pattern[^1]:
```
ip=<client-IP>:[<peer>]:<gateway-IP>:<netmask>:<client_hostname>:<interface>:{none|off|dhcp|on|any|dhcp6|auto6|ibft}[:[<dns1>][:<dns2>]] 
```
and we remove `esx` from excluded platforms for network reasons.

<hr>

Related to: https://github.com/flatcar-linux/Flatcar/issues/717

I'm not sure it takes a changelog entry

EDIT: don't merge this before getting the feature in stable - otherwise we'll prevent the impacted tests to run


[^1]: https://mirrors.edge.kernel.org/pub/linux/utils/boot/dracut/dracut.html#_network