### PR TITLE
docs: Replace flatcar-linux with flatcar

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,9 @@ and options.
 ## Tools
 
 ### cork
-Cork is a tool that helps working with Container Linux images and the SDK.
+Cork is a now-deprecated tool that was used to help in working with Container Linux images and the SDK.
 
-#### cork create
-Download and unpack the Container Linux SDK.
-
-`cork create`
-
-#### cork enter
-Enter the SDK chroot, and optionally run a command. The command and its
-arguments can be given after `--`.
-
-`cork enter -- repo sync`
-
-#### cork download-image
-Download a Container Linux image into `$PWD/.cache/images`.
-
-`cork download-image --platform=qemu`
-
-#### Building Container Linux with cork
-See [Modifying Container Linux](https://docs.flatcar-linux.org/os/sdk-modifying-coreos/) for
-an example of using cork to build a Container Linux image.
+Please see [developer guides](https://www.flatcar.org/docs/latest/reference/developer-guides/) to see how to work with Flatcar SDK.
 
 ### gangue
 Gangue is a tool for downloading and verifying files from Google Storage with authenticated requests.
@@ -93,7 +75,7 @@ cd mantle
 Alternatively, there is a container image with the required dependencies and the mantle binaries for the latest commit on `flatcar-master`:
 
 ```
-sudo docker run --privileged --net host -v /dev:/dev --rm -it ghcr.io/flatcar-linux/mantle:git-$(git rev-parse HEAD)
+sudo docker run --privileged --net host -v /dev:/dev --rm -it ghcr.io/flatcar/mantle:git-$(git rev-parse HEAD)
 # inside the container you can run "kola …" because it is in the PATH, and "sudo kola" is also not needed
 ```
 
@@ -219,7 +201,7 @@ kola package.  `Register(*Test)` is called per test. A kola `Test`
 struct requires a unique name, and a single function that is the entry
 point into the test. Additionally, userdata (such as a Container Linux
 Config) can be supplied. See the `Test` struct in
-[kola/register/register.go](https://github.com/flatcar-linux/mantle/tree/master/kola/register/register.go)
+[kola/register/register.go](https://github.com/flatcar/mantle/tree/master/kola/register/register.go)
 for a complete list of options.
 
 #### kola test writing
@@ -232,7 +214,7 @@ give you access to a running cluster of Container Linux machines. A test writer
 can interact with these machines through this interface.
 
 To see test examples look under
-[kola/tests](https://github.com/flatcar-linux/mantle/tree/master/kola/tests) in the
+[kola/tests](https://github.com/flatcar/mantle/tree/master/kola/tests) in the
 mantle codebase.
 
 For a quickstart see [kola/README.md](/kola/README.md).
@@ -250,7 +232,7 @@ a kola test using a `TestCluster`'s `RunNative` method. The function
 itself is then run natively on the specified running Container Linux instances.
 
 For more examples, look at the
-[coretest](https://github.com/flatcar-linux/mantle/tree/master/kola/tests/coretest)
+[coretest](https://github.com/flatcar/mantle/tree/master/kola/tests/coretest)
 suite of tests under kola. These tests were ported into kola and make
 heavy use of the native code interface.
 

--- a/kola/README.md
+++ b/kola/README.md
@@ -88,18 +88,18 @@ As an example, let's say you want to add a new test package called `foo`.
 
 1. First create `kola/tests/foo/`
 2. Then `echo "package foo" > kola/tests/foo/foo.go`
-3. Next, edit `kola/registry/registry.go` and add this to the imports `_ "github.com/flatcar-linux/mantle/kola/tests/foo"`
+3. Next, edit `kola/registry/registry.go` and add this to the imports `_ "github.com/flatcar/mantle/kola/tests/foo"`
 
 ```golang
 package registry
 
 // Tests imported for registration side effects. These make up the OS test suite and is explicitly imported from the main package.
 import (
-        _ "github.com/flatcar-linux/mantle/kola/tests/coretest"
-        _ "github.com/flatcar-linux/mantle/kola/tests/crio"
-        _ "github.com/flatcar-linux/mantle/kola/tests/docker"
-        _ "github.com/flatcar-linux/mantle/kola/tests/etcd"
-        _ "github.com/flatcar-linux/mantle/kola/tests/foo"
+        _ "github.com/flatcar/mantle/kola/tests/coretest"
+        _ "github.com/flatcar/mantle/kola/tests/crio"
+        _ "github.com/flatcar/mantle/kola/tests/docker"
+        _ "github.com/flatcar/mantle/kola/tests/etcd"
+        _ "github.com/flatcar/mantle/kola/tests/foo"
 <snip/>
 ```
 
@@ -126,17 +126,17 @@ import (
 package foo
 
 import (
-        "github.com/flatcar-linux/mantle/kola/cluster"
-        "github.com/flatcar-linux/mantle/kola/register"
+        "github.com/flatcar/mantle/kola/cluster"
+        "github.com/flatcar/mantle/kola/register"
 )
 
 // init runs when the package is imported and takes care of registering tests
 func init() {
-    register.Register(&register.Test{ // See: https://godoc.org/github.com/flatcar-linux/mantle/kola/register#Test
+    register.Register(&register.Test{ // See: https://godoc.org/github.com/flatcar/mantle/kola/register#Test
             Run:         exampleTestGroup,
             ClusterSize: 1,
             Name:        `example.example`,
-            Flags:       []register.Flag{}, // See: https://godoc.org/github.com/flatcar-linux/mantle/kola/register#Flag
+            Flags:       []register.Flag{}, // See: https://godoc.org/github.com/flatcar/mantle/kola/register#Flag
             Distros:     []string{"rhcos"},
             FailFast:    true,
     })
@@ -171,24 +171,24 @@ package registry
 
 // Tests imported for registration side effects. These make up the OS test suite and is explicitly imported from the main package.
 import (
-        _ "github.com/flatcar-linux/mantle/kola/tests/coretest"
-        _ "github.com/flatcar-linux/mantle/kola/tests/crio"
-        _ "github.com/flatcar-linux/mantle/kola/tests/docker"
-        _ "github.com/flatcar-linux/mantle/kola/tests/etcd"
-        _ "github.com/flatcar-linux/mantle/kola/tests/flannel"
-        _ "github.com/flatcar-linux/mantle/kola/tests/foo"
-        _ "github.com/flatcar-linux/mantle/kola/tests/ignition"
-        _ "github.com/flatcar-linux/mantle/kola/tests/kubernetes"
-        _ "github.com/flatcar-linux/mantle/kola/tests/locksmith"
-        _ "github.com/flatcar-linux/mantle/kola/tests/metadata"
-        _ "github.com/flatcar-linux/mantle/kola/tests/misc"
-        _ "github.com/flatcar-linux/mantle/kola/tests/ostree"
-        _ "github.com/flatcar-linux/mantle/kola/tests/packages"
-        _ "github.com/flatcar-linux/mantle/kola/tests/podman"
-        _ "github.com/flatcar-linux/mantle/kola/tests/rkt"
-        _ "github.com/flatcar-linux/mantle/kola/tests/rpmostree"
-        _ "github.com/flatcar-linux/mantle/kola/tests/systemd"
-        _ "github.com/flatcar-linux/mantle/kola/tests/torcx"
-        _ "github.com/flatcar-linux/mantle/kola/tests/update"
+        _ "github.com/flatcar/mantle/kola/tests/coretest"
+        _ "github.com/flatcar/mantle/kola/tests/crio"
+        _ "github.com/flatcar/mantle/kola/tests/docker"
+        _ "github.com/flatcar/mantle/kola/tests/etcd"
+        _ "github.com/flatcar/mantle/kola/tests/flannel"
+        _ "github.com/flatcar/mantle/kola/tests/foo"
+        _ "github.com/flatcar/mantle/kola/tests/ignition"
+        _ "github.com/flatcar/mantle/kola/tests/kubernetes"
+        _ "github.com/flatcar/mantle/kola/tests/locksmith"
+        _ "github.com/flatcar/mantle/kola/tests/metadata"
+        _ "github.com/flatcar/mantle/kola/tests/misc"
+        _ "github.com/flatcar/mantle/kola/tests/ostree"
+        _ "github.com/flatcar/mantle/kola/tests/packages"
+        _ "github.com/flatcar/mantle/kola/tests/podman"
+        _ "github.com/flatcar/mantle/kola/tests/rkt"
+        _ "github.com/flatcar/mantle/kola/tests/rpmostree"
+        _ "github.com/flatcar/mantle/kola/tests/systemd"
+        _ "github.com/flatcar/mantle/kola/tests/torcx"
+        _ "github.com/flatcar/mantle/kola/tests/update"
 )
 ```

--- a/platforms.md
+++ b/platforms.md
@@ -7,7 +7,7 @@ create images, collect logging information, etc.
 
 Authentication differs based on the platform. Some platforms like `aws` utilize the
 configuration files from their command-line tooling while others define their
-own custom configuration format and default locations (like [DigitalOcean](https://github.com/flatcar-linux/mantle/tree/master/auth/do.go)).
+own custom configuration format and default locations (like [DigitalOcean](https://github.com/flatcar/mantle/tree/master/auth/do.go)).
 Generally if any extensions / custom configurations are needed a new file is
 created inside of the `auth` package which will define the default location,
 the structure of the configuration, and a function to parse the configuration
@@ -22,27 +22,27 @@ functionality is present in the API.
 
 ## Cluster & Machine
 
-Clusters must implement the `Cluster` [interface](https://github.com/flatcar-linux/mantle/tree/master/platform/platform.go#L75-L97).
-Machines must implement the `Machine` [interface](https://github.com/flatcar-linux/mantle/tree/master/platform/platform.go#L40-L73).
+Clusters must implement the `Cluster` [interface](https://github.com/flatcar/mantle/tree/master/platform/platform.go#L75-L97).
+Machines must implement the `Machine` [interface](https://github.com/flatcar/mantle/tree/master/platform/platform.go#L40-L73).
 
 ## Adding a new platform to the kola runner
 
 To add a new platform to the `kola` runner the following things must be added:
  1. A platform specific struct inside of `cmd/kola/kola.go` which contains the
  fields that should be logged to give more information about a test run.
- Generally this will contain things like `version` or `ami` and `region`. [This](https://github.com/flatcar-linux/mantle/tree/master/cmd/kola/kola.go#L138-L142)
- is an example of the struct and [this](https://github.com/flatcar-linux/mantle/tree/master/cmd/kola/kola.go#L179-L183) shows the data
+ Generally this will contain things like `version` or `ami` and `region`. [This](https://github.com/flatcar/mantle/tree/master/cmd/kola/kola.go#L138-L142)
+ is an example of the struct and [this](https://github.com/flatcar/mantle/tree/master/cmd/kola/kola.go#L179-L183) shows the data
  being added to the output (which can be found in
  `_kola_temp/<platform>-latest/properties.json`).
  2. The platform specific options inside of `cmd/kola/options.go`
- ([for example DigitalOcean](https://github.com/flatcar-linux/mantle/tree/master/cmd/kola/kola.go#L179-L183)). The flags will
+ ([for example DigitalOcean](https://github.com/flatcar/mantle/tree/master/cmd/kola/kola.go#L179-L183)). The flags will
  generally contain an override for the configuration file location, region,
  type/size, and the image.
  3. The platform needs to be added to the `kolaPlatforms` list inside of
- `cmd/kola/options.go` [here](https://github.com/flatcar-linux/mantle/tree/master/cmd/kola/options.go#L32)
+ `cmd/kola/options.go` [here](https://github.com/flatcar/mantle/tree/master/cmd/kola/options.go#L32)
  4. The platform options & new cluster inside of `kola/harness.go`. The platform
- options variables are defined [here](https://github.com/flatcar-linux/mantle/tree/master/kola/harness.go#L54-L60) and the
- `NewCluster` method is defined [here](https://github.com/flatcar-linux/mantle/tree/master/kola/harness.go#L143-L161).
+ options variables are defined [here](https://github.com/flatcar/mantle/tree/master/kola/harness.go#L54-L60) and the
+ `NewCluster` method is defined [here](https://github.com/flatcar/mantle/tree/master/kola/harness.go#L143-L161).
 
 ## Other things to consider adding
 
@@ -79,7 +79,7 @@ create images from the image file.
  - The DO platform wraps [godo](https://github.com/digitalocean/godo).
  - By default SSH keys will be passed via both the DO metadata AND the userdata.
  - UserData is passed to the instances via the DO metadata service.
- - DigitalOcean has no method for uploading custom images, as a result the `ore do create-image` command does a [~~terrifying~~ special workaround](https://github.com/flatcar-linux/mantle/blob/master/cmd/ore/do/create-image.go#L117-L173) which specifies custom userdata that does the following (after which the machine is snapshotted):
+ - DigitalOcean has no method for uploading custom images, as a result the `ore do create-image` command does a [~~terrifying~~ special workaround](https://github.com/flatcar/mantle/blob/master/cmd/ore/do/create-image.go#L117-L173) which specifies custom userdata that does the following (after which the machine is snapshotted):
    - configure networking in the initramfs
    - Download a custom image
    - replaces `/root/initramfs/shutdown` with a script to:

--- a/runner-readme.md
+++ b/runner-readme.md
@@ -219,4 +219,4 @@ formats can be added by creating a new struct which implements the
 reporter inside of the `harness: Options` object created in
 `kola/harness: RunTests`.
 
-[For example](https://github.com/flatcar-linux/mantle/blob/52407c3ae8cd0837511c665af2c7870393e024bb/kola/harness.go#L295-L297) this is how the JSON reporter is added.
+[For example](https://github.com/flatcar/mantle/blob/52407c3ae8cd0837511c665af2c7870393e024bb/kola/harness.go#L295-L297) this is how the JSON reporter is added.


### PR DESCRIPTION
Also, cork is deprecated, so point to the correct location for documentation about working with SDK.

This is just fixing documentation files, so no code changes here.