### PR TITLE
Dockerfile: Add aws CLI tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /usr/src/mantle
 RUN cd /usr/src/mantle && ./build
 
 FROM docker.io/library/debian:11
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3 jq
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3 jq awscli
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg > /etc/apt/trusted.gpg.d/cloud.google.gpg && apt-get update -y && apt-get install --no-install-recommends -y python && apt-get install -y google-cloud-cli
 COPY --from=builder /usr/src/mantle/bin /usr/local/bin


### PR DESCRIPTION
The cloudformation update is done with the aws tool as of now, and we need it in the build pipeline https://github.com/flatcar/scripts/pull/475 until we move this logic into plume.


## How to use

## Testing done

Checked that https://github.com/flatcar/flatcar-build-scripts/blob/master/update-cloudformation-template can run in the container