### PR TITLE
openstack/api: wait for image to be active

### DIFF
--- a/platform/api/openstack/api.go
+++ b/platform/api/openstack/api.go
@@ -546,6 +546,18 @@ func (a *API) UploadImage(name, path string) (string, error) {
 			return "", fmt.Errorf("web uploading: %w", err)
 		}
 
+		// It usually takes around 10 seconds to extract the image.
+		if err := util.WaitUntilReady(1*time.Minute, 5*time.Second, func() (bool, error) {
+			image, err = images.Get(a.imageClient, image.ID).Extract()
+			if err != nil {
+				return false, fmt.Errorf("getting image status: %w", err)
+			}
+
+			return image.Status == images.ImageStatusActive, nil
+		}); err != nil {
+			return "", fmt.Errorf("getting image active: %w", err)
+		}
+
 		return image.ID, nil
 	}
 


### PR DESCRIPTION
the image usually takes a few second to be unpacked on the Openstack instance.

It can leads to CI error if the image used to run the test it not yet fully active.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>