### PR TITLE
kola: Ignore dead links in /usr/share/flatcar/etc

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -50,6 +50,9 @@ func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
 		// don't descend into these
 		"/proc",
 		"/sys",
+		// Symlinks in this directory get indirectly tested by
+		// going through /etc.
+		"/usr/share/flatcat/etc",
 		"/var/lib/docker",
 		"/var/lib/rkt",
 		"/var/lib/flatcar-oem-gce",


### PR DESCRIPTION
The relative dead symlinks there are copied verbatim by tmpfiles to `/etc`, where they should stop being dead. This test is going to go through those files in `/etc`, which we can treat as testing symlinks in `/usr/share/flatcar/etc`.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
