### PR TITLE
kola: Ping flatcar.org instead of coreos.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 ### Fixed
+- Fixed `cl.internet/DockerPing` test failures, because it was pinging a non-existent address ([#386](https://github.com/flatcar/mantle/pull/386))
 
 ## [v0.19.0] - 15/09/2022
 ### Security

--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -174,7 +174,7 @@ func TestDockerPing() error {
 	//t.Parallel()
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "ping", "-c4", "coreos.com")
+		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "ping", "-c4", "flatcar.org")
 		err := c.Run()
 		errc <- err
 	}()


### PR DESCRIPTION
The coreos.com address seems to be no more:

```
$ docker run ghcr.io/kinvolk/busybox ping -c4 coreos.com
ping: bad address 'coreos.com'
```

This is to fix `cl.internet/DockerPing` test failures that started to happen today:

  - http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3380/consoleText
  - http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3379/consoleText
  - http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3374/consoleText
  - http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3375/consoleText
