### PR TITLE
tests/ignition: add empty Ignition config test for openstack

### DIFF
--- a/kola/tests/ignition/empty.go
+++ b/kola/tests/ignition/empty.go
@@ -15,6 +15,7 @@
 package ignition
 
 import (
+	"github.com/coreos/go-semver/semver"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
 	"github.com/flatcar/mantle/platform/conf"
@@ -49,10 +50,11 @@ func init() {
 		Name:             "cl.ignition.v2.noop",
 		Run:              empty,
 		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu", "esx", "openstack"},
+		ExcludePlatforms: []string{"qemu", "esx"},
 		Distros:          []string{"cl"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignition":{"version":"2.0.0"}}`),
+		MinVersion:       semver.Version{Major: 3227},
 		// Should run on all cloud environments
 	})
 }


### PR DESCRIPTION
OpenStack should now support SSH keys provisioning from the OpenStack metadata server.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

I think it's ok to exclude current LTS from this test, because we still have the `cl.ignition.v1.noop` test and v1 is translated to v3, so this behavior will still be tested on the current LTS.

:warning: Do not merge this until https://github.com/flatcar/coreos-overlay/pull/2246 has been backported to all channels. (except LTS) :heavy_check_mark: 