### PR TITLE
plume: Use plain AMI image for uploads

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -191,7 +191,7 @@ func newAWSSpec() awsSpec {
 		BaseName:        "Flatcar",
 		BaseDescription: "Flatcar Container Linux",
 		Prefix:          "flatcar_production_ami_",
-		Image:           "flatcar_production_ami_vmdk_image.vmdk.bz2",
+		Image:           "flatcar_production_ami_image.bin.bz2",
 	}
 }
 

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -459,7 +459,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 
 		plog.Printf("Creating EBS snapshot...")
 
-		format := aws.EC2ImageFormatVmdk
+		format := aws.EC2ImageFormatRaw
 
 		snapshot, err = api.CreateSnapshot(imageName, s3ObjectURL, format)
 		if err != nil {
@@ -615,7 +615,7 @@ func awsUploadAmiLists(ctx context.Context, bucket *storage.Bucket, spec *channe
 
 // awsPreRelease runs everything necessary to prepare a Flatcar release for AWS.
 //
-// This includes uploading the ami_vmdk image to an S3 bucket in each EC2
+// This includes uploading the ami image to an S3 bucket in each EC2
 // partition, creating HVM AMIs, and replicating the AMIs to each
 // region.
 func awsPreRelease(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec, imageInfo *imageInfo) error {


### PR DESCRIPTION
Recently we ran into sporadic corruption issues for AWS EC2 AMIs. We use the streamOptimized VMDK format and it seems to cause problems at the AWS side, regardless if created by qemu-img or vmdk-convert. Switch to using the plain AMI images for uploading as workaround.

## How to use

When merged and the scripts repo has new mantle ref update PRs, merge them and retag the releases.

## Testing done

Will be tested as part of the release.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
