### PR TITLE
kola: Add custom Docker sysext test

### DIFF
--- a/kola/tests/systemd/sysext.go
+++ b/kola/tests/systemd/sysext.go
@@ -31,6 +31,22 @@ func init() {
         inline: |
           sysext works`),
 	})
+	register.Register(&register.Test{
+		Name:        "systemd.sysext.custom-docker",
+		Run:         checkSysextCustomDocker,
+		ClusterSize: 1,
+		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3185},
+		UserData: conf.ContainerLinuxConfig(`storage:
+  files:
+    - path: /etc/systemd/system-generators/torcx-generator
+  directories:
+    - path: /etc/extensions/docker-flatcar
+    - path: /etc/extensions/containerd-flatcar`),
+	})
+
 }
 
 func checkHelper(c cluster.TestCluster) {
@@ -49,4 +65,25 @@ func checkSysextSimple(c cluster.TestCluster) {
 	_ = c.MustSSH(c.Machines()[0], `sudo systemctl restart systemd-sysext`)
 	// Second check after reloading the extensions (e.g., to add/remove/update them)
 	checkHelper(c)
+}
+
+func checkSysextCustomDocker(c cluster.TestCluster) {
+	cmdNotWorking := `if docker run --rm ghcr.io/kinvolk/busybox true; then exit 1; fi`
+	cmdWorking := `docker run --rm ghcr.io/kinvolk/busybox echo Hello World`
+	// First assert that Docker doesn't work because Torcx is disabled
+	_ = c.MustSSH(c.Machines()[0], cmdNotWorking)
+	// We build a custom sysext image locally because we don't host them somewhere yet
+	_ = c.MustSSH(c.Machines()[0], `git clone https://github.com/flatcar/sysext-bakery.git && git -C sysext-bakery checkout 2d6ab6bdba96476138c7db841e9a4c4ed38bd3fc`)
+	// Flatcar has no mksquashfs and btrfs is missing a bugfix but at least ext4 works
+	// The first test is for a fixed Docker version, which with the time will get old and older but is still expected to work because users may also "freeze" their Docker version this way
+	_ = c.MustSSH(c.Machines()[0], `ONLY_DOCKER=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh 20.10.21 docker && ONLY_CONTAINERD=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh 20.10.21 containerd && sudo mv docker.raw containerd.raw /etc/extensions/`)
+	_ = c.MustSSH(c.Machines()[0], `sudo systemctl restart systemd-sysext`)
+	// We should now be able to use Docker
+	_ = c.MustSSH(c.Machines()[0], cmdWorking)
+	// The next test is with a recent Docker version, here the one from the Flatcar image to couple it to something that doesn't change under our feet
+	version := string(c.MustSSH(c.Machines()[0], `bzcat /usr/share/licenses/licenses.json.bz2 | grep -m 1 -o 'app-emulation/docker[^:]*' | cut -d - -f 3`))
+	_ = c.MustSSH(c.Machines()[0], `ONLY_DOCKER=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh `+version+` docker && ONLY_CONTAINERD=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh `+version+` containerd && sudo mv docker.raw containerd.raw /etc/extensions/`)
+	_ = c.MustSSH(c.Machines()[0], `sudo systemctl restart systemd-sysext && sudo systemctl restart docker containerd`)
+	// We should now still be able to use Docker
+	_ = c.MustSSH(c.Machines()[0], cmdWorking)
 }


### PR DESCRIPTION
This tests that users are able to supply a custom Docker version as sysext. It uses create_docker_sysext.sh which is documented in https://www.flatcar.org/docs/latest/provisioning/sysext/

## How to use

Replace branch checkout by git commit ID when https://github.com/flatcar/sysext-bakery/pull/6 is merged

## Testing done

`sudo ./kola run -d -k --keys --key ~/.ssh/id_rsa.pub  --board=amd64-usr --parallel=1 --platform=qemu  --qemu-image=flatcar_production_image.bin  --qemu-skip-mangle systemd.sysext.custom-docker`