### PR TITLE
kola/harness: run `SkipFunc` when version is available

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -206,7 +206,8 @@ func FilterTests(tests map[string]*register.Test, patterns []string, channel, of
 	}
 
 	for name, t := range tests {
-		if t.SkipFunc != nil && t.SkipFunc(version, channel, architecture(pltfrm), pltfrm) {
+		// The filtering is done twice, do not evaluate until we have fetched the version from the machine.
+		if version.Major != 0 && t.SkipFunc != nil && t.SkipFunc(version, channel, architecture(pltfrm), pltfrm) {
 			continue
 		}
 


### PR DESCRIPTION
`SkipFunc` is called from `FilterTests` and `FilterTests` is called twice: before and after spining-up a test instance to get the version.

We need to assert to be in the second case, where the version is actually defined - otherwise it simply ignores the test from the start.

Notified from the VMWare kubeadm that did not run on main nightly.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
