### PR TITLE
Dockerfile: Add azure-cli for image gallery publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN bash -c 'cd /usr/src/mantle && ./build ; mv bin bin-amd64 ; CGO_ENABLED=0 GO
 
 # See comment above about golang:1.19 why debian:11 is set here
 FROM docker.io/library/debian:11
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3 jq awscli
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3 jq awscli azure-cli
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg > /etc/apt/trusted.gpg.d/cloud.google.gpg && apt-get update -y && apt-get install --no-install-recommends -y python && apt-get install -y google-cloud-cli
 COPY --from=builder-amd64 /usr/src/mantle/bin-amd64 /usr/local/bin-amd64


### PR DESCRIPTION
While the mantle container has plume/ore for publishing cloud images, not all actions are implemented in plume or ore. We already have the awscli for some publishing steps but the "az" tool from azure-cli was missing and is useful for image gallery publishing.

## How to use

From https://github.com/flatcar/scripts/blob/380f9723290932e04f3a057a1a0cf04e7b56a93b/ci-automation/release.sh#L150

## Testing done

`docker run --rm -it ghcr.io/flatcar/mantle:pr-399` and then `az`