### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get tag name
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -34,22 +34,22 @@ jobs:
         fetch-depth: 0
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         push: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,19 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.13
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+    - name: Check out code
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: './go.mod'
 
     - name: Build
       run: make
 
     - name: Test
       run: make test
-      

--- a/.github/workflows/sync-calico-version.yml
+++ b/.github/workflows/sync-calico-version.yml
@@ -1,15 +1,15 @@
 name: Sync Calico version used for getting Tigera Operator manifest
 on:
   schedule:
-    # run every 12h
-    - cron:  '0 */12 * * *'
+    # run on Monday at 7
+    - cron:  '0 7 * * 1'
   workflow_dispatch:
 
 jobs:
   sync-calico-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update links to Tigera Operator manifest
         id: update-links
         run: |
@@ -18,10 +18,9 @@ jobs:
           calico_version=$(curl \
                              -H 'Accept: application/vnd.github+json' \
                              'https://api.github.com/repos/projectcalico/calico/releases' | \
-                           jq '.[].tag_name' | \
-                           sed -e 's/"\(.*\)"/\1/g' | \
+                           jq --raw-output '.[].tag_name' | \
                            sort --version-sort --reverse | \
-                           head -n1)
+                           head --lines 1)
 
           # The ':!.github' obviously means "exclude .github". This is to avoid
           # this action to mangle itself.
@@ -36,10 +35,10 @@ jobs:
           if git status --porcelain | grep --quiet '^ M'; then
             update_needed=1
           fi
-          echo ::set-output "name=CALICO_VERSION::${calico_version}"
-          echo ::set-output "name=UPDATE_NEEDED::${update_needed}"
+          echo "CALICO_VERSION=${calico_version}" >>"${GITHUB_OUTPUT}"
+          echo "UPDATE_NEEDED=${update_needed}" >>"${GITHUB_OUTPUT}"
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         if: steps.update-links.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- avoid warnings about using deprecated stuff
- take golang version from go.mod instead of hardcoding yet another golang version in the job
- run sync calico version once a week instead of twice a day

No need for the changelog entry.