### PR TITLE
kola: add output message for systemd-timesyncd v251

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed `cl.internet/DockerPing` test failures, because it was pinging a non-existent address ([#386](https://github.com/flatcar/mantle/pull/386))
+- Fixed `linux.ntp` test failures by adding output message for systemd-timesyncd v251 ([#402](https://github.com/flatcar/mantle/pull/402))
 
 ## [v0.19.0] - 15/09/2022
 ### Security

--- a/kola/tests/misc/ntp.go
+++ b/kola/tests/misc/ntp.go
@@ -28,6 +28,7 @@ var timesyncdMsgs = [][]byte{
 	[]byte(`Status: "Synchronized to time server 10.0.0.1:123 (10.0.0.1)."`),                    // systemd < 241
 	[]byte(`Status: "Synchronized to time server for the first time 10.0.0.1:123 (10.0.0.1)."`), // systemd >= 241
 	[]byte(`Status: "Initial synchronization to time server 10.0.0.1:123 (10.0.0.1)."`),         // systemd >= 243
+	[]byte(`Status: "Contacted time server 10.0.0.1:123 (10.0.0.1)."`),                          // systemd >= 251
 }
 
 func init() {


### PR DESCRIPTION
Since systemd v251, output messages of `systemd-timesyncd` started having a different format, not `Initial synchronization to time server`, but `Contacted time server`.
As a result, the `linux.ntp` test failed even when systemd-timesyncd ran without any issue.

```
ntp.go:80: unexpected systemd-timesyncd status: "systemd-timesyncd.service
Status: \"Contacted time server 10.0.0.1:123 (10.0.0.1).\"\n
Jan 03 18:43:08 localhost systemd[1]: Starting Network Time
Synchronization...\nJan 03 18:43:08 localhost systemd[1]: Started
Network Time Synchronization.\nJan 03 18:43:08 localhost
systemd-timesyncd[904]: Contacted time server 10.0.0.1:123
(10.0.0.1).\nJan 03 18:43:08 localhost systemd-timesyncd[904]: Initial
clock synchronization to Tue 2023-01-03 18:43:08.835535 UTC.
```

Add another entry for the new systemd-timesyncd output message.

See also https://github.com/systemd/systemd/commit/922a65082934c6169cd02f489edc2484b2c0a807.

## Testing done

local build passed

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
