### PR TITLE
platform/azure: fetch marketplace image plan info from endpoint

### DIFF
--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -40,17 +40,18 @@ var (
 )
 
 type API struct {
-	client     management.Client
-	rgClient   resources.GroupsClient
-	depClient  resources.DeploymentsClient
-	imgClient  compute.ImagesClient
-	compClient compute.VirtualMachinesClient
-	netClient  network.VirtualNetworksClient
-	subClient  network.SubnetsClient
-	ipClient   network.PublicIPAddressesClient
-	intClient  network.InterfacesClient
-	accClient  armStorage.AccountsClient
-	Opts       *Options
+	client      management.Client
+	rgClient    resources.GroupsClient
+	depClient   resources.DeploymentsClient
+	imgClient   compute.ImagesClient
+	compClient  compute.VirtualMachinesClient
+	vmImgClient compute.VirtualMachineImagesClient
+	netClient   network.VirtualNetworksClient
+	subClient   network.SubnetsClient
+	ipClient    network.PublicIPAddressesClient
+	intClient   network.InterfacesClient
+	accClient   armStorage.AccountsClient
+	Opts        *Options
 }
 
 type Network struct {
@@ -159,6 +160,8 @@ func (a *API) SetupClients() error {
 	a.imgClient.Authorizer = auther
 	a.compClient = compute.NewVirtualMachinesClient(settings.GetSubscriptionID())
 	a.compClient.Authorizer = auther
+	a.vmImgClient = compute.NewVirtualMachineImagesClient(settings.GetSubscriptionID())
+	a.vmImgClient.Authorizer = auther
 
 	auther, err = auth.NewAuthorizerFromFile(network.DefaultBaseURI)
 	if err != nil {


### PR DESCRIPTION
# platform/azure: fetch marketplace image plan info from endpoint

Fetch Azure marketplace plan information dynamically, so that `kola spawn` works for the Arm64 CoreVM offer.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

```
./bin/kola spawn --platform=azure --azure-location eastus2 --azure-publisher kinvolk --azure-offer flatcar-container-linux-corevm --azure-sku stable --azure-size "Standard_D2pls_v5" --azure-hyper-v-generation V2 --azure-auth ... --azure-profile ...
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
