### PR TITLE
tests/kubeadm: exclude k8s-1.26 from LTS tests

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -76,7 +76,7 @@ var (
 	// and the nested params are used to render script templates
 	testConfig = map[string]map[string]interface{}{
 		"v1.26.0": map[string]interface{}{
-			"MinMajorVersion": 3033,
+			"MinMajorVersion": 3374,
 			// from https://github.com/flannel-io/flannel/releases
 			"FlannelVersion": "v0.20.2",
 			// from https://github.com/cilium/cilium/releases


### PR DESCRIPTION
`containerd` is too old for running Kubernetes 1.26 on LTS
```
1Jan 17 00:32:53.106028 kubelet[1553]: E0117 00:32:53.105999    1553 run.go:74] "command failed" err="failed to run Kubelet: validate service connection: CRI v1 runtime API is not implemented for endpoint \"unix:///var/run/containerd/containerd.sock\": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"
```

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

No changelog.