### PR TITLE
kola/harness: Add more checks for common failures

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -161,6 +161,53 @@ var (
 			desc:  "core dump",
 			match: regexp.MustCompile("[Cc]ore dump"),
 		},
+		{
+			desc:  "ext4 filesystem corruption led to read-only mount",
+			match: regexp.MustCompile(`EXT4-fs \(.*\): Remounting filesystem read-only`),
+		},
+		{
+			desc:  "ext4 filesystem corruption",
+			match: regexp.MustCompile(`EXT4-fs error \(device .*\)|Aborting journal on device .*`),
+		},
+		{
+			desc:  "fsck.ext4 could not repair the filesystem unsupervised",
+			match: regexp.MustCompile("UNEXPECTED INCONSISTENCY; RUN fsck MANUALLY."),
+		},
+		{
+			desc:     "dm-verity detected disk corruption",
+			match:    regexp.MustCompile(`device-mapper: verity: \d+:\d+: data block \d+ is corrupted`),
+			skipFlag: &[]register.Flag{register.NoVerityCorruptionCheck}[0],
+		},
+		{
+			// With regexp in Go we can't do a Perl lookahead to exclude sr0 matches in the regular expression
+			// (would be 'dev (?!(sr0),).*, sector' and '(device|dev) (?!(sr0),).*, logical'),
+			// therefore, we just silence any found matches if the sr0 match was also around
+			desc:        "disk I/O errors",
+			match:       regexp.MustCompile(`blk_update_request: I/O error, dev .*, sector \d+|Buffer I/O error on (device|dev) .*, logical block \d+|EXT4-fs warning \(device .*\): .*:\d+: I/O error .* writing to inode \d+`),
+			skipIfMatch: regexp.MustCompile(`blk_update_request: I/O error, dev sr0, sector \d+|Buffer I/O error on (device|dev) sr0, logical block \d+`),
+		},
+		{
+			desc:     "systemd unit failed to start",
+			match:    regexp.MustCompile("Failed to start (.*)"),
+			skipFlag: &[]register.Flag{register.NoEmergencyShellCheck}[0],
+		},
+		{
+			desc:     "systemd dependency unit failed to start",
+			match:    regexp.MustCompile("Dependency failed for (.*)"),
+			skipFlag: &[]register.Flag{register.NoEmergencyShellCheck}[0],
+		},
+		{
+			desc:  "systemd default target unit dependencies not met",
+			match: regexp.MustCompile("Failed to isolate default target"),
+		},
+		{
+			desc:  "systemd froze execution",
+			match: regexp.MustCompile(`systemd\[1\]: Freezing execution`),
+		},
+		{
+			desc:  "systemd skipped execution of a unit due to an ordering cycle",
+			match: regexp.MustCompile("Ordering cycle found, skipping (.*)|Job (.*) deleted to break ordering cycle starting with (.*)|Found ordering cycle on (.*)"),
+		},
 	}
 )
 

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -27,11 +27,12 @@ import (
 type Flag int
 
 const (
-	NoSSHKeyInUserData    Flag = iota // don't inject SSH key into Ignition/cloud-config
-	NoSSHKeyInMetadata                // don't add SSH key to platform metadata
-	NoEmergencyShellCheck             // don't check console output for emergency shell invocation
-	NoEnableSelinux                   // don't enable selinux when starting or rebooting a machine
-	NoKernelPanicCheck                // don't check console output for kernel panic
+	NoSSHKeyInUserData      Flag = iota // don't inject SSH key into Ignition/cloud-config
+	NoSSHKeyInMetadata                  // don't add SSH key to platform metadata
+	NoEmergencyShellCheck               // don't check console output for emergency shell invocation
+	NoEnableSelinux                     // don't enable selinux when starting or rebooting a machine
+	NoKernelPanicCheck                  // don't check console output for kernel panic
+	NoVerityCorruptionCheck             // don't check console output for verity corruption
 )
 
 // Test provides the main test abstraction for kola. The run function is

--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -35,7 +35,7 @@ func init() {
 		Distros:     []string{"cl"},
 		// Somehow hangs
 		ExcludePlatforms: []string{"qemu-unpriv"},
-		Flags:            []register.Flag{register.NoKernelPanicCheck},
+		Flags:            []register.Flag{register.NoKernelPanicCheck, register.NoVerityCorruptionCheck},
 		MinVersion:       semver.Version{Major: 2943},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},

--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -245,7 +245,7 @@ func sysextBootLogic(c cluster.TestCluster) {
 	// a) stored on the rootfs and will stay there and the new one is is moved to the OEM partition
 	// b) stored on the OEM partition and gets moved to the rootfs and the new one is moved to the OEM partition
 	_ = c.MustSSH(noIgnition, fmt.Sprintf(`set -euxo pipefail
-sudo systemctl mask --now systemd-sysext
+sudo systemctl mask --now systemd-sysext ensure-sysext
 sudo mkdir -p /etc/flatcar/sysext /etc/flatcar/oem-sysext /usr/share/oem/sysext /etc/extensions
 echo ID=test | sudo tee /usr/share/oem/oem-release
 echo myext | sudo tee /etc/flatcar/enabled-sysext.conf
@@ -308,6 +308,8 @@ sudo ln -fs /etc/flatcar/sysext/flatcar-myext-1.2.3.raw /etc/extensions/flatcar-
 systemd:
   units:
     - name: systemd-sysext.service
+      mask: true
+    - name: ensure-sysext.service
       mask: true
 `, version))
 	withIgnition, err := c.NewMachine(conf)


### PR DESCRIPTION
When testing changes with kola and the tests do not cover the changed area we either have a booting system (that passes the tests) or don't. With additional generic checks we can catch introduced errors in an automated way and the manual booting to inspect a boot failure can also be saved if kola can hint at errors. Examples are broken changes in the systemd unit setup, when services start to fail, or when the disk is corrupted (be it due to a kernel bug, broken hardware, or a cloud provider image problem).
Add more checks for the above failures. If a test provokes one of these failures, the test and the pattern will have to be marked with a flag that skips the patterns for those tests only (this is what we already do for the existing patterns).

## How to use


## Testing done

Made a [full kola test run](http://jenkins.infra.kinvolk.io:8080/job/container/job/test_dispatcher/597/cldsv/) on all platforms (had to rerun some tests after pushing a fix for adding the right exclusion flags)