### PR TITLE
kola/tests: Also match combined systemd log format

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -215,11 +215,13 @@ func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 	found := false
 	// In v249, some services description have been updated.
 	// More details: https://github.com/systemd/systemd/commit/4fd3fc66396026f81fd5b27746f2faf8a9a7b9ee
-	// In v252, the printed line stoped using a description of the unit, going to the unit name.
+	// In v252, the printed line stopped using a description of the unit, going to the unit name but
+	// now we normally use the combined status format.
 	searchLinesNetworkd := []string{
 		"Started Network Service.",
 		"Started Network Configuration.",
 		"Started systemd-networkd.service.",
+		"Started systemd-networkd.service - Network Configuration.",
 	}
 	sort.Strings(searchLinesNetworkd)
 	for _, line := range lines {
@@ -235,6 +237,7 @@ func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 	searchLinesInitrd := []string{
 		"Reached target Switch Root.",
 		"Reached target initrd-switch-root.target.",
+		"Reached target initrd-switch-root.target - Switch Root.",
 	}
 	sort.Strings(searchLinesInitrd)
 	// check that we exited the initramfs first


### PR DESCRIPTION
The combined log format uses the form
"Started systemd-networkd.service - Network Configuration." to show both the unit name and the description.

## How to use



## Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/7283/console) 

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
