### PR TITLE
openstack/machine: get ipv4 for PrivateIP

### DIFF
--- a/platform/machine/openstack/machine.go
+++ b/platform/machine/openstack/machine.go
@@ -84,9 +84,18 @@ func (om *machine) PrivateIP() string {
 			if !ok {
 				continue
 			}
+
 			iptype, ok := a["OS-EXT-IPS:type"].(string)
-			ip, ok2 := a["addr"].(string)
-			if ok && ok2 && iptype == "fixed" {
+			if !ok || iptype != "fixed" {
+				continue
+			}
+
+			version, ok := a["version"].(float64)
+			if !ok || version != 4 {
+				continue
+			}
+
+			if ip, ok := a["addr"].(string); ok {
 				return ip
 			}
 		}


### PR DESCRIPTION
We duplicate the logic from eff11aad5cd3bc195b4aee7931b6ac2b63087062.

With recent devstack upgrade (to Zed) it seems that ipv6 was coming first.

<hr>

Otherwise, Kubernetes test was failing because external etcd was referenced through its ipv6