### PR TITLE
another sysext test + /usr/share/oem -> /oem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `DefaultUser` parameter when registering a test to use a user different from `core` ([#424](https://github.com/flatcar/mantle/pull/424))
+- `systemd.sysext.custom-oem` for testing the activation of the OEM sysext image ([#423](https://github.com/flatcar/mantle/pull/423))
 
 ### Change
+
+- Some tests dealing with OEM partition were duplicated or adapted for the OEM partition mountpoint move. The older versions of Flatcar will run tests for the old mountpoint location, the new enough versions - for both mountpoint locations. ([#423](https://github.com/flatcar/mantle/pull/423))
 
 ### Removed
 

--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -89,7 +89,7 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test overwrites the grub.cfg which does not work on cloud environments after reboot
 		Platforms:  []string{"qemu", "qemu-unpriv"},
-		MinVersion: semver.Version{Major: 3603},
+		MinVersion: semver.Version{Major: 3620},
 		UserData:   conf.Butane(withNewOEMMountpoint(regularButaneConfigTemplate)),
 	})
 	register.Register(&register.Test{
@@ -113,7 +113,7 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test overwrites the grub.cfg which does not work on cloud environments after reboot
 		Platforms:  []string{"qemu", "qemu-unpriv"},
-		MinVersion: semver.Version{Major: 3603},
+		MinVersion: semver.Version{Major: 3620},
 		UserData:   conf.Butane(withNewOEMMountpoint(indirectButaneConfigTemplate)),
 	})
 	register.Register(&register.Test{

--- a/kola/tests/ignition/oem.go
+++ b/kola/tests/ignition/oem.go
@@ -61,19 +61,6 @@ storage:
           # Needed if --qemu-skip-mangle is not set
           set linux_console="console=ttyS0,115200"
 `
-	reuseContainerLinuxConfig string = `storage:
-  filesystems:
-     - name: oem
-       mount:
-         device: "/dev/disk/by-label/OEM"
-         format: "ext4"
-  files:
-    - path: /grub.cfg
-      filesystem: oem
-      mode: 0644
-      contents:
-        inline: |
-          set linux_append="flatcar.autologin"`
 )
 
 func withOldOEMMountpoint(template string) string {
@@ -138,18 +125,19 @@ func init() {
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 2983},
 		// Using CLC format here also covers the ign-converter case
-		UserData: conf.ContainerLinuxConfig(reuseContainerLinuxConfig),
-	})
-	register.Register(&register.Test{
-		Name:        "cl.ignition.oem.reuse.new",
-		Run:         reusePartitionNew,
-		ClusterSize: 1,
-		Distros:     []string{"cl"},
-		// This test overwrites the grub.cfg which does not work on cloud environments after reboot
-		Platforms:  []string{"qemu", "qemu-unpriv"},
-		MinVersion: semver.Version{Major: 3603},
-		// Using CLC format here also covers the ign-converter case
-		UserData: conf.ContainerLinuxConfig(reuseContainerLinuxConfig),
+		UserData: conf.ContainerLinuxConfig(`storage:
+  filesystems:
+     - name: oem
+       mount:
+         device: "/dev/disk/by-label/OEM"
+         format: "ext4"
+  files:
+    - path: /grub.cfg
+      filesystem: oem
+      mode: 0644
+      contents:
+        inline: |
+          set linux_append="flatcar.autologin"`),
 	})
 	register.Register(&register.Test{
 		Name:        "cl.ignition.oem.wipe",

--- a/kola/tests/systemd/sysext.go
+++ b/kola/tests/systemd/sysext.go
@@ -4,14 +4,266 @@
 package systemd
 
 import (
+	"bytes"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"text/template"
+	"time"
+	"unicode"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
+	"github.com/flatcar/mantle/platform"
 	"github.com/flatcar/mantle/platform/conf"
+	"github.com/flatcar/mantle/platform/local"
+	"github.com/flatcar/mantle/platform/machine/qemu"
+	"github.com/flatcar/mantle/platform/machine/unprivqemu"
+	"github.com/flatcar/mantle/util"
+)
+
+// BEGIN FOR UTILS
+func trimLeftSpace(contents string) string {
+	return strings.TrimLeftFunc(contents, unicode.IsSpace)
+}
+
+// END FOR UTILS
+
+type (
+	downloadScriptParameters struct {
+		ImageDirectoryURLTemplate string
+	}
+
+	configTemplateParameters struct {
+		DownloadScriptBase64Contents     string
+		DevContainerScriptBase64Contents string
+		MainScriptBase64Contents         string
+		CheckScriptBase64Contents        string
+	}
+)
+
+var (
+	// BEGIN FOR UTILS
+	downloadScriptTemplate = trimLeftSpace(`
+#!/bin/bash
+
+set -x
+
+set -euo pipefail
+
+output_bin="${1}"
+
+function process_template() {
+        local template="${1}"; shift
+        local arch="${1}"; shift
+        local version="${1}"; shift
+        local result="${template}"
+
+        result="${result//@ARCH@/${arch}}"
+        result="${result//@VERSION@/${version}}"
+
+        echo "${result}"
+}
+
+source /usr/share/flatcar/release
+
+ARCH="${FLATCAR_RELEASE_BOARD/-usr/}"
+VERSION="${FLATCAR_RELEASE_VERSION}"
+IMAGE_URL=$(process_template '{{ .ImageDirectoryURLTemplate }}/flatcar_developer_container.bin.bz2' "${ARCH}" "${VERSION}")
+
+echo "Fetching developer container from ${IMAGE_URL}"
+# Stolen from copy_from_buildcache in ci_automation_common.sh. Not
+# using --output-dir option as this seems to be quite a new addition
+# and curl on older version of Flatcar does not understand it.
+curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+        --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+        --remote-name "${IMAGE_URL}"
+
+bzip2cat=bzcat
+if command -v lbzcat; then
+        bzip2cat=lbzcat
+fi
+
+# The image file takes over 6Gb after normal unpacking, but a lot of
+# it is just zeros. Use cp --sparse=always to avoid unnecessary disk
+# space waste. Especially that we may not have 6Gb of disk space
+# available.
+cp --sparse=always <("${bzip2cat}" flatcar_developer_container.bin.bz2) "${output_bin}"
+`)
+	// END FOR UTILS
+
+	devContainerScript = trimLeftSpace(`
+#!/bin/bash
+
+set -x
+
+set -euo pipefail
+
+version=$(source /etc/os-release; echo "${VERSION}")
+version_id=$(source /etc/os-release; echo "${VERSION_ID}")
+board=$(source /usr/share/flatcar/release; echo "${FLATCAR_RELEASE_BOARD}")
+
+mkdir -p /work/sysext_rootfs/usr/share/flatcar-sysext-kola-test
+echo "${version_id}" >/work/sysext_rootfs/usr/share/flatcar-sysext-kola-test/file
+mkdir -p /work/sysext_rootfs/usr/lib/extension-release.d
+sysext_arch=x86-64
+if [[ "${board}" = 'arm64-usr' ]]; then sysext_arch=arm64; fi
+metadata=(
+    'ID=flatcar'
+    "VERSION_ID=${version_id}"
+    "ARCHITECTURE=${sysext_arch}"
+)
+metadata_file=/work/sysext_rootfs/usr/lib/extension-release.d/extension-release.oem-test
+printf '%s\n' "${metadata[@]}" >"${metadata_file}"
+mksquashfs /work/sysext_rootfs "/work/oem-test-${version}.raw" -all-root
+`)
+
+	mainScript = trimLeftSpace(`
+#!/bin/bash
+
+set -x
+
+set -euo pipefail
+
+/home/core/download-script.sh flatcar_developer_container.bin
+
+# This is where the built sysext will be stored
+workdir="${PWD}/dev-container-workdir-${RANDOM}"
+mkdir -p "${workdir}"
+
+sudo systemd-nspawn \
+        --console=pipe \
+        --bind-ro=/home/core/dev-container-script.sh \
+        --bind="${workdir}:/work" \
+        --image=flatcar_developer_container.bin \
+        --machine=flatcar-developer-container \
+        /bin/bash /home/core/dev-container-script.sh
+
+version=$(source /etc/os-release; echo "${VERSION}")
+sysext_file="${workdir}/oem-test-${version}.raw"
+
+if [[ ! -e "${sysext_file}" ]]; then
+        echo "Expected ${sysext_file} to exist, contents of workdir:"
+        ls -la "${workdir}"
+        exit 1
+fi
+
+# Rebrand our image from "qemu" to "test".
+if [[ ! -e /oem/oem-release ]]; then
+        # This is the regular case, on the generic image used for kola
+        # QEMU tests there is no OEM setup
+        printf '%s\n' 'ID=test' 'VERSION_ID=1.0.0' 'NAME=testing stuff' | sudo tee /oem/oem-release >/dev/null
+else
+        # This only works when the OEM setup is optional, e.g., with
+        # the QEMU OEM image
+        sudo sed -i'' -e 's/^ID=.*/ID=test/' /oem/oem-release
+fi
+sudo mkdir -p /oem/sysext
+sudo mv "${sysext_file}" /oem/sysext
+sudo touch /oem/sysext/active-oem-test
+# We keep /var/log to keep journald logs in case something goes wrong.
+sudo flatcar-reset --keep-machine-id --keep-paths /var/log
+`)
+
+	checkScript = trimLeftSpace(`
+#!/bin/bash
+
+set -x
+
+set -euo pipefail
+
+list_out=$(systemd-sysext list --json=pretty)
+status_out=$(systemd-sysext status --json=pretty)
+printf 'sysext list:\n%s\nsysext status:\n%s\n' "${list_out}" "${status_out}"
+
+list_oem_test=$(jq '.[] | select(.name == "oem-test")' <<<"${list_out}")
+
+if [[ -z "${list_oem_test}" ]]; then
+        echo "oem-test image is not listed"
+        exit 1
+fi
+
+oem_test_type=$(jq --raw-output '.type' <<<"${list_oem_test}")
+if [[ "${oem_test_type}" != 'raw' ]]; then
+        echo "oem test image type should be 'raw', is '${oem_test_type}'"
+        exit 1
+fi
+
+oem_test_path=$(jq --raw-output '.path' <<<"${list_oem_test}")
+if [[ "${oem_test_path}" != '/etc/extensions/oem-test.raw' ]]; then
+        echo "oem test image path should be '/etc/extensions/oem-test.raw', is '${oem_test_path}'"
+        exit 1
+fi
+
+status_usr=$(jq '.[] | select(.hierarchy == "/usr")' <<<"${status_out}")
+if [[ -z "${status_usr}" ]]; then
+        echo "no sysext hierarchy for /usr?"
+        exit 1
+fi
+
+status_usr_extensions_oem_test=$(jq --raw-output '.extensions[] | select(. == "oem-test")' <<<"${status_usr}")
+if [[ "${status_usr_extensions_oem_test}" != 'oem-test' ]]; then
+        echo "oem-test sysext is not active on /usr"
+        exit 1
+fi
+
+f=/usr/share/flatcar-sysext-kola-test/file
+if [[ ! -e "${f}" ]]; then
+        echo "Missing file from sysext"
+        exit 1
+fi
+got=$(cat "${f}")
+ex=$(source /etc/os-release; echo "${VERSION_ID}")
+if [[ "${got}" != "${ex}" ]]; then
+        echo "Bad content of sysext file (got '${got}', expected '${ex}')"
+        exit 1
+fi
+`)
+
+	butaneTemplate = trimLeftSpace(`
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /home/core/download-script.sh
+      mode: 0755
+      contents:
+        source: "data:text/plain;base64,{{ .DownloadScriptBase64Contents }}"
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/dev-container-script.sh
+      mode: 0755
+      contents:
+        source: "data:text/plain;base64,{{ .DevContainerScriptBase64Contents }}"
+      user:
+        name: core
+      group:
+        name: core
+    - path: /home/core/main-script.sh
+      mode: 0755
+      contents:
+        source: "data:text/plain;base64,{{ .MainScriptBase64Contents }}"
+      user:
+        name: core
+      group:
+        name: core
+    - path: /oem/check-script.sh
+      # set overwrite to true as flatcar-reset will not remove it
+      overwrite: true
+      mode: 0755
+      contents:
+        source: "data:text/plain;base64,{{ .CheckScriptBase64Contents }}"
+      user:
+        name: core
+      group:
+        name: core
+`)
 )
 
 func init() {
@@ -50,7 +302,18 @@ func init() {
     - path: /etc/extensions/docker-flatcar
     - path: /etc/extensions/containerd-flatcar`),
 	})
-
+	register.Register(&register.Test{
+		Name:        "systemd.sysext.custom-oem",
+		Run:         checkSysextCustomOEM,
+		ClusterSize: 0,
+		Distros:     []string{"cl"},
+		// This test is uses its own OEM files and shouldn't run on other platforms
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3605},
+		NativeFuncs: map[string]func() error{
+			"Http": Serve,
+		},
+	})
 }
 
 func checkHelper(c cluster.TestCluster) {
@@ -98,3 +361,121 @@ func checkSysextCustomDocker(c cluster.TestCluster) {
 	// We should now still be able to use Docker
 	_ = c.MustSSH(c.Machines()[0], cmdWorking)
 }
+
+func checkSysextCustomOEM(c cluster.TestCluster) {
+	// BEGIN COPIED STUFF
+	devcontainerURL := kola.DevcontainerURL
+	if kola.DevcontainerFile != "" {
+		// This URL is deterministic as it runs on the started machine.
+		devcontainerURL = "http://localhost:8080"
+	}
+	// END COPIED STUFF
+
+	userdata, err := prepareUserData(devcontainerURL)
+	if err != nil {
+		c.Fatalf("preparing user data failed: %v", err)
+	}
+	// BEGIN COPIED STUFF
+	machine, err := newMachineWithLargeDisk(c, userdata)
+	if err != nil {
+		c.Fatalf("creating a machine failed: %v", err)
+	}
+
+	if kola.DevcontainerFile != "" {
+		configureHTTPServer(c, machine)
+	}
+	// END COPIED STUFF
+
+	if _, err := c.SSH(machine, "/home/core/main-script.sh"); err != nil {
+		c.Fatalf("main script failed: %v", err)
+	}
+	if err := machine.Reboot(); err != nil {
+		c.Fatalf("could not reboot: %v", err)
+	}
+	if _, err := c.SSH(machine, "/oem/check-script.sh"); err != nil {
+		c.Fatalf("check script failed: %v", err)
+	}
+}
+
+func prepareUserData(devContainerURL string) (*conf.UserData, error) {
+	scriptParameters := downloadScriptParameters{
+		ImageDirectoryURLTemplate: devContainerURL,
+	}
+	downloadScript, err := executeTemplate(downloadScriptTemplate, "download script", scriptParameters)
+	if err != nil {
+		return nil, err
+	}
+	downloadScriptBase64 := base64.StdEncoding.EncodeToString(([]byte)(downloadScript))
+	mainScriptBase64 := base64.StdEncoding.EncodeToString(([]byte)(mainScript))
+	devContainerScriptBase64 := base64.StdEncoding.EncodeToString(([]byte)(devContainerScript))
+	checkScriptBase64 := base64.StdEncoding.EncodeToString(([]byte)(checkScript))
+	configParameters := configTemplateParameters{
+		DownloadScriptBase64Contents:     downloadScriptBase64,
+		DevContainerScriptBase64Contents: devContainerScriptBase64,
+		MainScriptBase64Contents:         mainScriptBase64,
+		CheckScriptBase64Contents:        checkScriptBase64,
+	}
+	config, err := executeTemplate(butaneTemplate, "butane config", configParameters)
+	if err != nil {
+		return nil, err
+	}
+	return conf.Butane(config), nil
+}
+
+// BEGIN COPIED STUFF
+func executeTemplate(contents, name string, parameters any) (string, error) {
+	tmpl, err := template.New(name).Parse(contents)
+	if err != nil {
+		return "", fmt.Errorf("parsing %s as a template failed: %w", name, err)
+	}
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, parameters); err != nil {
+		return "", fmt.Errorf("executing %s template failed: %w", name, err)
+	}
+	return buf.String(), nil
+}
+
+func newMachineWithLargeDisk(c cluster.TestCluster, userData *conf.UserData) (platform.Machine, error) {
+	options := platform.MachineOptions{
+		ExtraPrimaryDiskSize: "5G",
+	}
+	switch pc := c.Cluster.(type) {
+	case *qemu.Cluster:
+		return pc.NewMachineWithOptions(userData, options)
+	case *unprivqemu.Cluster:
+		return pc.NewMachineWithOptions(userData, options)
+	}
+	return nil, errors.New("unknown cluster type, this test should only be running on qemu or qemu-unpriv platforms")
+}
+
+func Serve() error {
+	httpServer := local.SimpleHTTP{}
+	return httpServer.Serve()
+}
+
+func configureHTTPServer(c cluster.TestCluster, srv platform.Machine) {
+	// manually copy Kolet on the host, as the initial size cluster is 0.
+	kola.ScpKolet(c, strings.SplitN(kola.QEMUOptions.Board, "-", 2)[0])
+
+	in, err := os.Open(kola.DevcontainerFile)
+	if err != nil {
+		c.Fatalf("opening dev container file: %v", err)
+	}
+
+	defer in.Close()
+
+	if err := platform.InstallFile(in, srv, "/var/www/flatcar_developer_container.bin.bz2"); err != nil {
+		c.Fatalf("copying dev container to HTTP server: %v", err)
+	}
+
+	c.MustSSH(srv, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s Http", c.H.Name()))
+
+	if err := util.WaitUntilReady(60*time.Second, 5*time.Second, func() (bool, error) {
+		_, _, err := srv.SSH(fmt.Sprintf("curl %s:8080", srv.PrivateIP()))
+		return err == nil, nil
+	}); err != nil {
+		c.Fatal("timed out waiting for http server to become active")
+	}
+}
+
+// END COPIED STUFF

--- a/kola/tests/util/devcontainer.go
+++ b/kola/tests/util/devcontainer.go
@@ -1,0 +1,185 @@
+// Copyright The Mantle Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/flatcar/mantle/kola"
+	"github.com/flatcar/mantle/kola/cluster"
+	"github.com/flatcar/mantle/platform"
+	"github.com/flatcar/mantle/platform/conf"
+	"github.com/flatcar/mantle/platform/local"
+	"github.com/flatcar/mantle/platform/machine/qemu"
+	"github.com/flatcar/mantle/platform/machine/unprivqemu"
+	mutil "github.com/flatcar/mantle/util"
+)
+
+type (
+	downloadLibraryParameters struct {
+		ImageDirectoryURLTemplate string
+	}
+)
+
+var (
+	downloadLibraryTemplate = TrimLeftSpace(`
+#!/bin/bash
+
+# Takes a template, architecture and version and prints the template
+# with all instances of @ARCH@ replaced with the passed architecture
+# and all instances of @VERSION@ replaced with the passed version.
+#
+# Example:
+# url=$(process_template 'https://example.com/@ARCH@/@VERSION@/image.bz2' 'amd64' '1.2.3')
+function process_template {
+        local template="${1}"; shift
+        local arch="${1}"; shift
+        local version="${1}"; shift
+        local result="${template}"
+
+        result="${result//@ARCH@/${arch}}"
+        result="${result//@VERSION@/${version}}"
+
+        echo "${result}"
+}
+
+# Downloads the developer container image and decompresses it. The
+# result is stored in the passed path.
+#
+# Example:
+# download_dev_container_image flatcar_devcontainer.bin
+function download_dev_container_image {
+        local output_bin="${1}"; shift
+
+        local arch version image_url bzip2cat
+
+        arch=$(source /usr/share/flatcar/release; echo "${FLATCAR_RELEASE_BOARD/-usr/}")
+        version=$(source /usr/share/flatcar/release; echo "${FLATCAR_RELEASE_VERSION}")
+        image_url=$(process_template '{{ .ImageDirectoryURLTemplate }}/flatcar_developer_container.bin.bz2' "${arch}" "${version}")
+
+        echo "Fetching developer container from ${image_url}"
+        # Stolen from copy_from_buildcache in ci_automation_common.sh. Not
+        # using --output-dir option as this seems to be quite a new addition
+        # and curl on older version of Flatcar does not understand it.
+        curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+                --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+                --remote-name "${image_url}"
+
+        bzip2cat=bzcat
+        if command -v lbzcat; then
+                bzip2cat=lbzcat
+        fi
+
+        # The image file takes over 6Gb after normal unpacking, but a lot of
+        # it is just zeros. Use cp --sparse=always to avoid unnecessary disk
+        # space waste. Especially that we may not have 6Gb of disk space
+        # available.
+        cp --sparse=always <("${bzip2cat}" flatcar_developer_container.bin.bz2) "${output_bin}"
+}
+`)
+)
+
+// TrimLeftSpace trims leading whitespace. Useful for defining script
+// as string variables, like:
+//
+// var (
+//
+//	script = util.TrimLeftSpace(`
+//
+// #!/bin/bash
+// …
+// `)
+func TrimLeftSpace(contents string) string {
+	return strings.TrimLeftFunc(contents, unicode.IsSpace)
+}
+
+// DevContainerDownloadLibrary generates a bash library that could be
+// sourced on the machine to import two functions: process_template
+// and download_dev_container_image.
+//
+// The source of the developer container image can be specified using
+// --devcontainer-url or --devcontainer-file options.
+func DevContainerDownloadLibrary() (string, error) {
+	devcontainerURL := kola.DevcontainerURL
+	if kola.DevcontainerFile != "" {
+		// This URL is deterministic as it runs on the started machine.
+		devcontainerURL = "http://localhost:8080"
+	}
+	libraryParameters := downloadLibraryParameters{
+		ImageDirectoryURLTemplate: devcontainerURL,
+	}
+	return ExecNamedTemplate(downloadLibraryTemplate, "download library", libraryParameters)
+}
+
+// NewMachineWithLargeDisk creates a new machine on the passed qemu or
+// qemu-unpriv cluster. The extraSize parameter is a string describing
+// size, like "5G".
+func NewMachineWithLargeDisk(c cluster.TestCluster, extraSize string, userData *conf.UserData) (platform.Machine, error) {
+	options := platform.MachineOptions{
+		ExtraPrimaryDiskSize: extraSize,
+	}
+	switch pc := c.Cluster.(type) {
+	case *qemu.Cluster:
+		return pc.NewMachineWithOptions(userData, options)
+	case *unprivqemu.Cluster:
+		return pc.NewMachineWithOptions(userData, options)
+	}
+	return nil, errors.New("unknown cluster type, this test should only be running on qemu or qemu-unpriv platforms")
+}
+
+// Serve is a function that could be used as a native function for
+// running a simple HTTP server inside cluster machines.
+func Serve() error {
+	httpServer := local.SimpleHTTP{}
+	return httpServer.Serve()
+}
+
+// ConfigureDevContainerHTTPServer sets up the local HTTP server to
+// provide the compressed developer container image if such is
+// available through --devcontainer-file.
+func ConfigureDevContainerHTTPServer(c cluster.TestCluster, srv platform.Machine) error {
+	if kola.DevcontainerFile == "" {
+		// Not using local file as a source of developer
+		// container, so no need to configure the local HTTP
+		// server.
+		return nil
+	}
+	// Manually copy Kolet on the host, as the initial size cluster may be 0.
+	if err := kola.UploadKolet(c, strings.SplitN(kola.QEMUOptions.Board, "-", 2)[0]); err != nil {
+		return fmt.Errorf("uploading kolet to machine: %w", err)
+	}
+
+	in, err := os.Open(kola.DevcontainerFile)
+	if err != nil {
+		return fmt.Errorf("opening dev container file: %w", err)
+	}
+
+	defer in.Close()
+
+	if err := platform.InstallFile(in, srv, "/var/www/flatcar_developer_container.bin.bz2"); err != nil {
+		return fmt.Errorf("copying dev container to HTTP server: %w", err)
+	}
+
+	if _, err := c.SSH(srv, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s Http", c.H.Name())); err != nil {
+		return err
+	}
+
+	if err := mutil.WaitUntilReady(60*time.Second, 5*time.Second, func() (bool, error) {
+		_, _, err := srv.SSH(fmt.Sprintf("curl %s:8080", srv.PrivateIP()))
+		return err == nil, nil
+	}); err != nil {
+		return fmt.Errorf("timed out waiting for http server to become active")
+	}
+	return nil
+}
+
+func ToBase64(input string) string {
+	return base64.StdEncoding.EncodeToString(([]byte)(input))
+}

--- a/kola/tests/util/template.go
+++ b/kola/tests/util/template.go
@@ -16,19 +16,25 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
 )
 
 func ExecTemplate(tmplStr string, tmplData interface{}) (string, error) {
-	var out bytes.Buffer
+	return ExecNamedTemplate(tmplStr, "", tmplData)
+}
 
-	tmpl, err := template.New("").Parse(tmplStr)
+func ExecNamedTemplate(contents, name string, parameters any) (string, error) {
+	if name == "" {
+		name = "unnamed stuff"
+	}
+	tmpl, err := template.New(name).Parse(contents)
 	if err != nil {
-		return out.String(), err
+		return "", fmt.Errorf("parsing %s as a template failed: %w", name, err)
 	}
-
-	if err := tmpl.Execute(&out, tmplData); err != nil {
-		return out.String(), err
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, parameters); err != nil {
+		return "", fmt.Errorf("executing %s template failed: %w", name, err)
 	}
-	return out.String(), nil
+	return buf.String(), nil
 }

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -291,7 +291,7 @@ func (a *API) CreateOrUpdateDevice(hostname string, conf *conf.Conf, console Con
 	}
 
 	// The Ignition config can't go in userdata via coreos.config.url=https://metadata.packet.net/userdata because Ignition supplies an Accept header that metadata.packet.net finds 406 Not Acceptable.
-	// It can't go in userdata via coreos.oem.id=packet because the EquinixMetal OEM expects unit files in /usr/share/oem which the PXE image doesn't have.
+	// It can't go in userdata via coreos.oem.id=packet because the EquinixMetal OEM expects unit files in /oem (or /usr/share/oem) which the PXE image doesn't have.
 	userdataName, userdataURL, err := a.uploadObject(hostname, "application/vnd.coreos.ignition+json", []byte(userdata))
 	if err != nil {
 		return nil, err
@@ -499,7 +499,7 @@ systemctl --no-block isolate reboot.target
 		},
 		Storage: ignition.Storage{
 			Files: []ignition.File{
-				ignition.File{
+				{
 					Filesystem: "root",
 					Path:       "/userdata",
 					Contents: ignition.FileContents{
@@ -510,7 +510,7 @@ systemctl --no-block isolate reboot.target
 					},
 					Mode: 0644,
 				},
-				ignition.File{
+				{
 					Filesystem: "root",
 					Path:       "/noop.ign",
 					Contents: ignition.FileContents{
@@ -521,7 +521,7 @@ systemctl --no-block isolate reboot.target
 					},
 					Mode: 0644,
 				},
-				ignition.File{
+				{
 					Filesystem: "root",
 					Path:       "/root/bin/coreos-cloudinit",
 					Contents: ignition.FileContents{
@@ -532,7 +532,7 @@ systemctl --no-block isolate reboot.target
 					},
 					Mode: 0755,
 				},
-				ignition.File{
+				{
 					Filesystem: "root",
 					Path:       "/opt/installer",
 					Contents: ignition.FileContents{
@@ -547,27 +547,27 @@ systemctl --no-block isolate reboot.target
 		},
 		Systemd: ignition.Systemd{
 			Units: []ignition.SystemdUnit{
-				ignition.SystemdUnit{
+				{
 					// don't appear to be running while install is in progress
 					Name: "sshd.socket",
 					Mask: true,
 				},
-				ignition.SystemdUnit{
+				{
 					// future-proofing
 					Name: "sshd.service",
 					Mask: true,
 				},
-				ignition.SystemdUnit{
+				{
 					// allow remote detection of install in progress
 					Name:     "discard.socket",
 					Enable:   true,
 					Contents: discardSocketUnit,
 				},
-				ignition.SystemdUnit{
+				{
 					Name:     "discard@.service",
 					Contents: discardServiceUnit,
 				},
-				ignition.SystemdUnit{
+				{
 					Name:     "flatcar-install.service",
 					Enable:   true,
 					Contents: installUnit,


### PR DESCRIPTION
This adds a new sysext test that builds and activates an OEM sysext image. It also prepares the tests for the move of the OEM partition mountpoint move from `/usr/share/oem` to `/oem`. It required duplicating some of the tests, so the variants with `/usr/share/oem` will be run for Flatcar versions lower than 3603.0.0 (so new alpha release being 3602.0.0 will run the `/usr/share/oem` variants), and the variants with `/oem` will be run for Flatcar 3603.0.0 or newer.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
