### PR TITLE
Replace kinvolk links and docker images with flatcar ones, sync docker images

### DIFF
--- a/.github/workflows/mirror-calico-images.sh
+++ b/.github/workflows/mirror-calico-images.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script will mirror the list of Calico images
+# from Docker Hub to GHCR.
+
+set -euo pipefail
+
+this_dir=$(dirname "${0}")
+
+org="${1}"
+# tag will hold the version of calico images we
+# previously fetched
+tag="${2}"
+
+# list of images to mirror from Docker Hub
+images=(
+  calico/typha
+  calico/pod2daemon-flexvol
+  calico/cni
+  calico/node
+  calico/kube-controllers
+)
+
+# we iterate over the images we want to mirror
+for image in "${images[@]}"; do
+  "${this_dir}/mirror-to-ghcr.sh" -o "${org}" "${image}" "${tag}"
+done

--- a/.github/workflows/mirror-stable-docker-images.yaml
+++ b/.github/workflows/mirror-stable-docker-images.yaml
@@ -1,0 +1,34 @@
+name: Sync GHCR images with stable Docker Hub images
+on:
+  schedule:
+    # run on Monday at 7
+    - cron:  '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      ghcr_org:
+        type: string
+        required: false
+        default: flatcar
+        description: |
+          The name of the GitHub org where the docker images should be pushed.
+
+jobs:
+  mirror-stable-docker-images:
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [nginx,busybox]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out scripts
+        uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry (ghcr)
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mirror ${{ matrix.package }} stable image as latest to GHCR
+        run: .github/workflows/mirror-to-ghcr.sh -t latest -o ${{ inputs.ghcr_org }} ${{ matrix.package }} stable

--- a/.github/workflows/mirror-to-ghcr.sh
+++ b/.github/workflows/mirror-to-ghcr.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This generic script aims to mirror an image from Docker hub to another registry.
+# Authentication to the registry must be done before.
+
+set -euo pipefail
+
+function fail {
+    echo "${*}" >&2
+    exit 1
+}
+
+org=flatcar
+ghcrtag=''
+while [[ -n "${1:-}" ]]; do
+    case "${1}" in
+        -o)
+            if [[ -z "${2:-}" ]]; then
+                fail "No meaningful value for ${1}"
+            fi
+            org="${2}"
+            shift 2
+            ;;
+        -t)
+            if [[ -z "${2:-}" ]]; then
+                fail "No meaningful value for ${1}"
+            fi
+            ghcrtag="${2}"
+            shift 2
+            ;;
+        -*)
+            echo 'invalid flag'
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+image="${1:-}"
+if [[ -z "${image}" ]]; then
+    fail "Empty image name"
+fi
+imagetag="${2}"
+if [[ -z "${imagetag}" ]]; then
+    fail "Empty image tag"
+fi
+if [[ -z "${ghcrtag}" ]]; then
+    ghcrtag="${imagetag}"
+fi
+
+# we want both arch for running tests
+platforms=( amd64 arm64 )
+
+# tags will hold the mirrored images
+tags=()
+
+srcname="${image}:${imagetag}"
+dstname="ghcr.io/${org}/${image}:${ghcrtag}"
+
+for platform in "${platforms[@]}"; do
+    # we first fetch the image from Docker Hub
+    var=$(docker pull "${srcname}" --platform="linux/${platform}" -q)
+    # we prepare the image to be pushed into another registry
+    tag="${dstname}-${platform}"
+    # we tag the image to create the mirrored image
+    docker tag "${var}" "${tag}"
+    docker push "${tag}"
+    tags+=( "${tag}" )
+done
+
+docker manifest create "${dstname}" "${tags[@]}"
+# some images have bad arch specs in the individual image manifests :(
+docker manifest annotate "${dstname}" "${dstname}-arm64" --arch arm64
+docker manifest push --purge "${dstname}"

--- a/.github/workflows/sync-calico-version.yml
+++ b/.github/workflows/sync-calico-version.yml
@@ -33,7 +33,6 @@ jobs:
           branch: calico-update-${{ steps.update-links.outputs.CALICO_VERSION }}
           title: Update calico to ${{ steps.update-links.outputs.CALICO_VERSION }}
           commit-message: Update calico to ${{ steps.update-links.outputs.CALICO_VERSION }}
-          team-reviewers: flatcar/flatcar-maintainers
           delete-branch: true
       - name: Login to GitHub Container Registry (ghcr)
         if: steps.update-links.outputs.UPDATE_NEEDED == 1

--- a/.github/workflows/sync-calico-version.yml
+++ b/.github/workflows/sync-calico-version.yml
@@ -1,15 +1,27 @@
-name: Sync Calico version used for getting Tigera Operator manifest
+name: Update Tigera Operator manifest to latest release and sync docker images
 on:
   schedule:
     # run on Monday at 7
     - cron:  '0 7 * * 1'
   workflow_dispatch:
+    inputs:
+      ghcr_org:
+        type: string
+        required: false
+        default: flatcar
+        description: |
+          The name of the GitHub org where the docker images should be pushed.
 
 jobs:
   sync-calico-version:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out scripts
+        uses: actions/checkout@v3
       - name: Update links to Tigera Operator manifest
         id: update-links
         run: .github/workflows/sync-calico-version.sh
@@ -21,5 +33,17 @@ jobs:
           branch: calico-update-${{ steps.update-links.outputs.CALICO_VERSION }}
           title: Update calico to ${{ steps.update-links.outputs.CALICO_VERSION }}
           commit-message: Update calico to ${{ steps.update-links.outputs.CALICO_VERSION }}
-          reviewers: flatcar/flatcar-maintainers
+          team-reviewers: flatcar/flatcar-maintainers
           delete-branch: true
+      - name: Login to GitHub Container Registry (ghcr)
+        if: steps.update-links.outputs.UPDATE_NEEDED == 1
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mirror calico images to GHCR
+        if: steps.update-links.outputs.UPDATE_NEEDED == 1
+        env:
+          CALICO_VERSION: ${{ steps.update-links.outputs.CALICO_VERSION }}
+        run: .github/workflows/mirror-calico-images.sh ${{ inputs.ghcr_org }} "${CALICO_VERSION}"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The easiest way to get started with `kola` is to run a `qemu` test.
 From the pulled sources, `kola` and `kolet` must be compiled:
 
 ```shell
-git clone https://github.com/kinvolk/mantle/
+git clone https://github.com/flatcar/mantle/
 cd mantle
 ./build kola kolet
 ```
@@ -80,8 +80,8 @@ sudo docker run --privileged --net host -v /dev:/dev --rm -it ghcr.io/flatcar/ma
 ```
 
 Finally, a Flatcar image must be available on the system:
-  - from a locally [built](https://kinvolk.io/docs/flatcar-container-linux/latest/reference/developer-guides/sdk-modifying-flatcar/) image
-  - from an official [release](https://kinvolk.io/flatcar-container-linux/releases/)
+  - from a locally [built](https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/) image
+  - from an official [release](https://www.flatcar.org/releases)
 
 ###### Run tests for AMD64
 

--- a/kola/README.md
+++ b/kola/README.md
@@ -2,7 +2,7 @@
 
 ## Quick Start
 
-1. Fork and clone the [`mantle` repository](https://github.com/kinvolk/mantle/)
+1. Fork and clone the [`mantle` repository](https://github.com/flatcar/mantle/)
 2. Move into `kola/tests/` and look for the package your test would best fit
 3. Edit the file and add your test(s), ensuring that you register your new test(s) in the packages `init()`
 4. Commit, push, and PR your result

--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -155,7 +155,7 @@ func TestDockerEcho() error {
 	//t.Parallel()
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "echo")
+		c := exec.Command("docker", "run", "ghcr.io/flatcar/busybox", "echo")
 		err := c.Run()
 		errc <- err
 	}()
@@ -174,7 +174,7 @@ func TestDockerPing() error {
 	//t.Parallel()
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "ping", "-c4", "flatcar.org")
+		c := exec.Command("docker", "run", "ghcr.io/flatcar/busybox", "ping", "-c4", "flatcar.org")
 		err := c.Run()
 		errc <- err
 	}()

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -648,7 +648,7 @@ func dockerSELinux(c cluster.TestCluster) {
 	var cmd string
 
 	cmd = `sudo mkdir /etc/misc && \
-docker run -v "/etc/misc:/opt" --rm ghcr.io/kinvolk/busybox true`
+docker run -v "/etc/misc:/opt" --rm ghcr.io/flatcar/busybox true`
 
 	// assert SELinux is in permissive mode
 	if err := c.MustSSH(m, "sudo setenforce 0"); err != nil {
@@ -666,12 +666,12 @@ docker run -v "/etc/misc:/opt" --rm ghcr.io/kinvolk/busybox true`
 	}
 
 	// run docker command to assert it fails because of wrong labeling
-	if _, err := c.SSH(m, `docker run -v "/etc/misc:/opt" --rm ghcr.io/kinvolk/busybox sh -c "echo world > /opt/hello"`); err == nil {
+	if _, err := c.SSH(m, `docker run -v "/etc/misc:/opt" --rm ghcr.io/flatcar/busybox sh -c "echo world > /opt/hello"`); err == nil {
 		c.Fatalf("command should raise a permission error")
 	}
 
 	// run docker command with correct relabel action (z)
-	if err := c.MustSSH(m, `docker run -v "/etc/misc:/opt:z" --rm ghcr.io/kinvolk/busybox sh -c "echo world > /opt/hello"`); err != nil {
+	if err := c.MustSSH(m, `docker run -v "/etc/misc:/opt:z" --rm ghcr.io/flatcar/busybox sh -c "echo world > /opt/hello"`); err != nil {
 		c.Fatalf("unable to run docker command: %v", err)
 	}
 

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -259,7 +259,7 @@ func dockerBaseTests(c cluster.TestCluster) {
 // using a simple container, exercise various docker options that set resource
 // limits and security options. also acts as a regression test for
 // https://github.com/coreos/bugs/issues/1246 and
-// https://github.com/kinvolk/Flatcar/issues/110
+// https://github.com/flatcar/Flatcar/issues/110
 func dockerResources(c cluster.TestCluster) {
 	m := c.Machines()[0]
 

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -351,7 +351,7 @@ metadata:
   name: default
 spec:
   # Use GH container registry to get rid of Docker limitation.
-  registry: ghcr.io
+  registry: ghcr.io/
   imagePath: flatcar/calico
   # Configures Calico networking.
   calicoNetwork:

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -117,7 +117,8 @@ storage:
         inline: |
           {
               "log-driver": "journald"
-          }`
+          }
+`
 
 	masterConfig = `systemd:
   units:{{ if .cgroupv1 }}
@@ -262,7 +263,8 @@ storage:
                 - name: nginx
                   image: ghcr.io/flatcar/nginx
                   ports:
-                  - containerPort: 80`
+                  - containerPort: 80
+`
 
 	masterScript = `#!/bin/bash
 set -euo pipefail
@@ -480,5 +482,6 @@ EOF
 systemctl start --quiet coreos-metadata
 ipv4=$(cat /run/metadata/flatcar | grep -v -E '(IPV6|GATEWAY)' | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
 
-kubeadm join --config worker-config.yaml --node-name "${ipv4}"`
+kubeadm join --config worker-config.yaml --node-name "${ipv4}"
+`
 )

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -260,7 +260,7 @@ storage:
               spec:
                 containers:
                 - name: nginx
-                  image: ghcr.io/kinvolk/nginx
+                  image: ghcr.io/flatcar/nginx
                   ports:
                   - containerPort: 80`
 
@@ -350,7 +350,7 @@ metadata:
 spec:
   # Use GH container registry to get rid of Docker limitation.
   registry: ghcr.io
-  imagePath: kinvolk/calico
+  imagePath: flatcar/calico
   # Configures Calico networking.
   calicoNetwork:
     # Note: The ipPools section cannot be modified post-install.

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -83,7 +83,7 @@ metadata:
   name: default
 spec:
   # Use GH container registry to get rid of Docker limitation.
-  registry: ghcr.io
+  registry: ghcr.io/
   imagePath: flatcar/calico
   # Configures Calico networking.
   calicoNetwork:

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -84,7 +84,7 @@ metadata:
 spec:
   # Use GH container registry to get rid of Docker limitation.
   registry: ghcr.io
-  imagePath: kinvolk/calico
+  imagePath: flatcar/calico
   # Configures Calico networking.
   calicoNetwork:
     # Note: The ipPools section cannot be modified post-install.

--- a/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
@@ -131,6 +131,6 @@ storage:
               spec:
                 containers:
                 - name: nginx
-                  image: ghcr.io/kinvolk/nginx
+                  image: ghcr.io/flatcar/nginx
                   ports:
                   - containerPort: 80

--- a/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
@@ -131,6 +131,6 @@ storage:
               spec:
                 containers:
                 - name: nginx
-                  image: ghcr.io/kinvolk/nginx
+                  image: ghcr.io/flatcar/nginx
                   ports:
                   - containerPort: 80

--- a/kola/tests/systemd/sysext.go
+++ b/kola/tests/systemd/sysext.go
@@ -79,8 +79,8 @@ func checkSysextCustomDocker(c cluster.TestCluster) {
 		arch = "x86_64"
 	}
 
-	cmdNotWorking := `if docker run --rm ghcr.io/kinvolk/busybox true; then exit 1; fi`
-	cmdWorking := `docker run --rm ghcr.io/kinvolk/busybox echo Hello World`
+	cmdNotWorking := `if docker run --rm ghcr.io/flatcar/busybox true; then exit 1; fi`
+	cmdWorking := `docker run --rm ghcr.io/flatcar/busybox echo Hello World`
 	// First assert that Docker doesn't work because Torcx is disabled
 	_ = c.MustSSH(c.Machines()[0], cmdNotWorking)
 	// We build a custom sysext image locally because we don't host them somewhere yet


### PR DESCRIPTION
- replaced some links
- replaced kinvolk/busybox, kinvolk/nginx and kinvolk/calico with flatcar variants
  - https://github.com/flatcar/scripts/pull/716 needs to go in and the actions there need to be run first
- fixed a final newline issue with kubeadm templates