### PR TITLE
.github: Fix usage of inputs in scheduled action runs

### DIFF
--- a/.github/workflows/mirror-stable-docker-images.yaml
+++ b/.github/workflows/mirror-stable-docker-images.yaml
@@ -31,4 +31,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Mirror ${{ matrix.package }} stable image as latest to GHCR
-        run: .github/workflows/mirror-to-ghcr.sh -t latest -o ${{ inputs.ghcr_org }} ${{ matrix.package }} stable
+        env:
+          GHCR_ORG: ${{ inputs.ghcr_org }}
+          PACKAGE: ${{ matrix.package }}
+        run: .github/workflows/mirror-to-ghcr.sh -t latest -o "${GHCR_ORG:-flatcar}" "${PACKAGE}" stable

--- a/.github/workflows/sync-calico-version.yml
+++ b/.github/workflows/sync-calico-version.yml
@@ -45,4 +45,5 @@ jobs:
         if: steps.update-links.outputs.UPDATE_NEEDED == 1
         env:
           CALICO_VERSION: ${{ steps.update-links.outputs.CALICO_VERSION }}
-        run: .github/workflows/mirror-calico-images.sh ${{ inputs.ghcr_org }} "${CALICO_VERSION}"
+          GHCR_ORG: ${{ inputs.ghcr_org }}
+        run: .github/workflows/mirror-calico-images.sh "${GHCR_ORG:-flatcar}" "${CALICO_VERSION}"


### PR DESCRIPTION
I thought that scheduled action runs will use default values for the specified inputs, but in reality all the inputs are null for such runs. This is kinda lame, as we need to specify the default value in two places now.
