### PR TITLE
kola/tests/systemd: Try also different category for docker package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Change
 
 - Some tests dealing with OEM partition were duplicated or adapted for the OEM partition mountpoint move. The older versions of Flatcar will run tests for the old mountpoint location, the new enough versions - for both mountpoint locations. ([#423](https://github.com/flatcar/mantle/pull/423))
+- The `systemd.sysext.custom-docker` test now tries to figure out the distributed Docker version by searching for both `app-emulation/docker` and `app-containers/docker` package information. The older versions of Flatcar use the former, the new versions will use the latter ([#438](https://github.com/flatcar/mantle/pull/438))
 
 ### Removed
 

--- a/kola/tests/systemd/sysext.go
+++ b/kola/tests/systemd/sysext.go
@@ -317,7 +317,7 @@ func checkSysextCustomDocker(c cluster.TestCluster) {
 	// We should now be able to use Docker
 	_ = c.MustSSH(c.Machines()[0], cmdWorking)
 	// The next test is with a recent Docker version, here the one from the Flatcar image to couple it to something that doesn't change under our feet
-	version := string(c.MustSSH(c.Machines()[0], `bzcat /usr/share/licenses/licenses.json.bz2 | grep -m 1 -o 'app-emulation/docker[^:]*' | cut -d - -f 3`))
+	version := string(c.MustSSH(c.Machines()[0], `bzcat /usr/share/licenses/licenses.json.bz2 | grep -m 1 -o 'app-\(containers\|emulation\)/docker-[0-9][^:]*' | cut -d - -f 3`))
 	_ = c.MustSSH(c.Machines()[0], fmt.Sprintf(`ONLY_DOCKER=1 FORMAT=ext4 ARCH=%[2]s sysext-bakery/create_docker_sysext.sh %[1]s docker && ONLY_CONTAINERD=1 FORMAT=ext4 ARCH=%[2]s sysext-bakery/create_docker_sysext.sh %[1]s containerd && sudo mv docker.raw containerd.raw /etc/extensions/`, version, arch))
 	_ = c.MustSSH(c.Machines()[0], `sudo systemctl restart systemd-sysext && sudo systemctl restart docker containerd`)
 	// We should now still be able to use Docker


### PR DESCRIPTION
We will move docker packages from app-emulation to app-containers to match what Gentoo did with their docker packages. Since the tests will be also running on older versions of Flatcar, keep searching for docker package in old category too.
