### PR TITLE
kola: Skip devcontainer test if not available

### DIFF
--- a/kola/tests/util/devcontainer.go
+++ b/kola/tests/util/devcontainer.go
@@ -64,6 +64,11 @@ function download_dev_container_image {
         version=$(source /usr/share/flatcar/release; echo "${FLATCAR_RELEASE_VERSION}")
         image_url=$(process_template '{{ .ImageDirectoryURLTemplate }}/flatcar_developer_container.bin.bz2' "${arch}" "${version}")
 
+        if [ "$(curl -I --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 -L -s -o /dev/null -w "%{http_code}" "${image_url}")" = 404 ]; then
+          echo "Skipping test because the devcontainer is not available" >&2
+          exit 0
+        fi
+
         echo "Fetching developer container from ${image_url}"
         # Stolen from copy_from_buildcache in ci_automation_common.sh. Not
         # using --output-dir option as this seems to be quite a new addition


### PR DESCRIPTION
The test will fail on external PRs or locally built images because the devcontainer can't be downloaded.
Skip the test if the download has no chance to succeed.

## How to use


## Testing done


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
