### PR TITLE
kola: Add new OEM sysext update and migration test

### DIFF
--- a/kola/tests/util/update.go
+++ b/kola/tests/util/update.go
@@ -31,8 +31,8 @@ func AssertBootedUsr(c cluster.TestCluster, m platform.Machine, usr string) {
 }
 
 func GetUsrDeviceNode(c cluster.TestCluster, m platform.Machine) string {
-	// find /usr dev
-	usrdev := c.MustSSH(m, "findmnt -no SOURCE /usr")
+	// find /usr dev (-f to see the first mount, not the sysext overlay mount)
+	usrdev := c.MustSSH(m, "findmnt -fno SOURCE /usr")
 
 	// XXX: if the /usr dev is /dev/mapper/usr, we're on a verity enabled
 	// image, so use dmsetup to find the real device.


### PR DESCRIPTION
The A/B updated OEM systemd-sysext image gets activated when both /usr partitions have updated to a version that requires a sysext image. The old OEM contents get cleaned in this migration that happens on the boot after the final update.
Test this migration and update logic by starting from an old image that isn't migrated, and emulate an OEM setup that requires an OEM sysext image now. The update first happens with the inbuilt Omaha kolet server which uses the fallback logic but then flatcar-update is used for the second update to supply the OEM payload directly.

## How to use

See scripts PR: https://github.com/flatcar/scripts/pull/1016

## Testing done

Manual and on [Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/13949/console)