### PR TITLE
openstack/api: delete image "container" when download fails

### DIFF
--- a/platform/api/openstack/api.go
+++ b/platform/api/openstack/api.go
@@ -555,6 +555,7 @@ func (a *API) UploadImage(name, path string) (string, error) {
 
 			return image.Status == images.ImageStatusActive, nil
 		}); err != nil {
+			a.DeleteImage(image.ID)
 			return "", fmt.Errorf("getting image active: %w", err)
 		}
 


### PR DESCRIPTION
if the image is failing to be ready in the given retry loop, we can delete the image "container" otherwise OpenStack will still try to download the image which will eventually will work but for nothing.
