### PR TITLE
kola/nvidia: Change the nvidia retry clause

### DIFF
--- a/kola/tests/misc/nvidia.go
+++ b/kola/tests/misc/nvidia.go
@@ -38,8 +38,8 @@ func verifyNvidiaInstallation(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	nvidiaStatusRetry := func() error {
-		out, err := c.SSH(m, "systemctl is-active nvidia.service")
-		if !bytes.Contains(out, []byte("inactive")) {
+		out, err := c.SSH(m, "systemctl status nvidia.service")
+		if !bytes.Contains(out, []byte("active (exited)")) {
 			return fmt.Errorf("nvidia.service: %q: %v", out, err)
 		}
 		return nil


### PR DESCRIPTION
The nvidia.service has been change to `oneshot` and sets `RemainAfterExit=true` which keeps the service active after it exits.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
