### PR TITLE
api/aws: support `--aws-ami=lts` for test/spawning

### DIFF
--- a/platform/api/aws/ami.go
+++ b/platform/api/aws/ami.go
@@ -39,6 +39,9 @@ var amiCache struct {
 
 	stableOnce sync.Once
 	stableAMIs *releaseAMIs
+
+	ltsOnce sync.Once
+	ltsAMIs *releaseAMIs
 }
 
 // resolveAMI is used to minimize network requests while allowing resolution of
@@ -77,6 +80,11 @@ func resolveAMI(ami string, region string) string {
 			amiCache.stableAMIs = resolveChannel(ami)
 		})
 		channelAmis = amiCache.stableAMIs
+	case "lts":
+		amiCache.ltsOnce.Do(func() {
+			amiCache.ltsAMIs = resolveChannel(ami)
+		})
+		channelAmis = amiCache.ltsAMIs
 	default:
 		return ami
 	}


### PR DESCRIPTION
it allows to use the 'lts' channel when testing quickly with kola using

---

Locally tested with: `kola --platform aws --aws-ami stable ... spawn`