### PR TITLE
kola: Disable the public update server by default

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -565,6 +565,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
 		NoEnableSelinux:    t.HasFlag(register.NoEnableSelinux),
+		NoDisableUpdates:   t.HasFlag(register.NoDisableUpdates),
 		SSHRetries:         Options.SSHRetries,
 		SSHTimeout:         Options.SSHTimeout,
 		DefaultUser:        t.DefaultUser,

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -33,6 +33,7 @@ const (
 	NoEnableSelinux                     // don't enable selinux when starting or rebooting a machine
 	NoKernelPanicCheck                  // don't check console output for kernel panic
 	NoVerityCorruptionCheck             // don't check console output for verity corruption
+	NoDisableUpdates                    // don't disable usage of the public update server
 )
 
 // Test provides the main test abstraction for kola. The run function is

--- a/kola/tests/ignition/empty.go
+++ b/kola/tests/ignition/empty.go
@@ -32,7 +32,10 @@ func init() {
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu", "esx"},
 		Distros:          []string{"cl"},
-		UserData:         conf.Empty(),
+		// The userdata injection of disabling the update server won't work
+		// for an empty config, we still take care of doing later it via SSH
+		Flags:    []register.Flag{register.NoDisableUpdates, register.NoSSHKeyInUserData},
+		UserData: conf.Empty(),
 		// Should run on all cloud environments
 	})
 	// Tests for https://github.com/coreos/bugs/issues/1981
@@ -59,5 +62,7 @@ func init() {
 	})
 }
 
-func empty(_ cluster.TestCluster) {
+func empty(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	_ = c.MustSSH(m, "echo SERVER=disabled | sudo tee /etc/flatcar/update.conf")
 }

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -39,8 +39,13 @@ func init() {
 		ClusterSize: 3,
 		// When cl.etcd-member.discovery runs on all clouds to test CLC IP templating, we can skip running this
 		Platforms: []string{"qemu", "qemu-unpriv"},
+		// This test already specifies the update.conf file in the userdata.
+		// Disabling of the public server is done explicitly.
+		Flags: []register.Flag{register.NoDisableUpdates},
 		UserData: conf.ContainerLinuxConfig(`locksmith:
   reboot_strategy: etcd-lock
+update:
+  server: disabled
 etcd:
   version:                     3.5.0
   listen_client_urls:          http://0.0.0.0:2379
@@ -60,8 +65,11 @@ etcd:
 		Distros:   []string{"cl"},
 	})
 	register.Register(&register.Test{
-		Name:        "coreos.locksmith.tls",
-		Run:         locksmithTLS,
+		Name: "coreos.locksmith.tls",
+		Run:  locksmithTLS,
+		// This test already specifies the update.conf file in the userdata.
+		// Disabling of the public server is done explicitly.
+		Flags:       []register.Flag{register.NoDisableUpdates},
 		ClusterSize: 1,
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
@@ -95,7 +103,7 @@ etcd:
       {
         "filesystem": "root",
         "path": "/etc/coreos/update.conf",
-        "contents": { "source": "data:,REBOOT_STRATEGY=etcd-lock%0A" },
+        "contents": { "source": "data:,REBOOT_STRATEGY=etcd-lock%0ASERVER=disabled%0A" },
         "mode": 420
       },
       {

--- a/kola/tests/misc/omaha.go
+++ b/kola/tests/misc/omaha.go
@@ -31,6 +31,8 @@ func init() {
 		Run:         OmahaPing,
 		ClusterSize: 0,
 		Name:        "cl.omaha.ping",
+		// This test already sets its own update server in the userdata
+		Flags: []register.Flag{register.NoDisableUpdates},
 		// This test is normally not related to the cloud environment
 		Platforms:        []string{"qemu"},
 		ExcludePlatforms: []string{"qemu-unpriv"},

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -191,6 +191,12 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
+	// disable the public update server by default
+	if !bc.rconf.NoDisableUpdates {
+		conf.AddFile("/etc/flatcar/update.conf", "root", `SERVER=disabled
+`, 0644)
+	}
+
 	// disable Zincati & Pinger by default
 	if bc.Distribution() == "fcos" {
 		conf.AddFile("/etc/fedora-coreos-pinger/config.d/90-disable-reporting.toml", "root", `[reporting]

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -175,6 +175,7 @@ type RuntimeConfig struct {
 	NoSSHKeyInUserData bool          // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata bool          // don't add SSH key to platform metadata
 	NoEnableSelinux    bool          // don't enable selinux when starting or rebooting a machine
+	NoDisableUpdates   bool          // don't disable usage of the public update server
 	AllowFailedUnits   bool          // don't fail CheckMachine if a systemd unit has failed
 	SSHRetries         int           // see SSHRetries field in Options
 	SSHTimeout         time.Duration // see SSHTimeout field in Options


### PR DESCRIPTION
This might have been an oversight: for release tests we used the public Nebraska server. This was already disabled for FCOS but not for the original CoreOS/Flatcar CL.
Disable the public update server by default. The update tests overwrite it with their specific setting. In case a future test needs the default the usual test flag escape hatch in the form of NoDisableUpdates is added.

## How to use


## Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/container/job/test_dispatcher/2526/cldsv/)
