### PR TITLE
Kola: update to handle torcx deprecation / docker and containerd sysext

### DIFF
--- a/kola/README.md
+++ b/kola/README.md
@@ -187,8 +187,8 @@ import (
         _ "github.com/flatcar/mantle/kola/tests/podman"
         _ "github.com/flatcar/mantle/kola/tests/rkt"
         _ "github.com/flatcar/mantle/kola/tests/rpmostree"
+        _ "github.com/flatcar/mantle/kola/tests/sysext"
         _ "github.com/flatcar/mantle/kola/tests/systemd"
-        _ "github.com/flatcar/mantle/kola/tests/torcx"
         _ "github.com/flatcar/mantle/kola/tests/update"
 )
 ```

--- a/kola/registry/registry.go
+++ b/kola/registry/registry.go
@@ -18,7 +18,7 @@ import (
 	_ "github.com/flatcar/mantle/kola/tests/packages"
 	_ "github.com/flatcar/mantle/kola/tests/podman"
 	_ "github.com/flatcar/mantle/kola/tests/rpmostree"
+	_ "github.com/flatcar/mantle/kola/tests/sysext"
 	_ "github.com/flatcar/mantle/kola/tests/systemd"
-	_ "github.com/flatcar/mantle/kola/tests/torcx"
 	_ "github.com/flatcar/mantle/kola/tests/update"
 )

--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -87,14 +87,13 @@ func execsnoopTest(c cluster.TestCluster) {
 	_ = c.MustSSH(m, fmt.Sprintf("docker logs %s", containerName))
 	_ = c.MustSSH(m, fmt.Sprintf("docker top %s", containerName))
 
-
 	plog.Infof("getting logs from %s container", containerName)
 	if err := util.Retry(10, 2*time.Second, func() error {
 		logs, err := c.SSH(m, fmt.Sprintf("sudo cat $(docker inspect --format='{{.LogPath}}' %s)", containerName))
 		if err != nil {
 			c.Fatalf("unable to run SSH command: %v", err)
 		}
-		dockerLogs:= bytes.Split(logs, []byte("\n"))
+		dockerLogs := bytes.Split(logs, []byte("\n"))
 
 		// we have the headers of the table
 		// then 2 lines for docker ps and the torcx call if torcx is used

--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -48,83 +48,79 @@ func init() {
 }
 
 func execsnoopTest(c cluster.TestCluster) {
-	c.Run("filter name and args", func(c cluster.TestCluster) {
-		m := c.Machines()[0]
-		containerName := "execsnoop"
+	m := c.Machines()[0]
+	containerName := "execsnoop"
 
-		// filter commands with `docker ps`
-		plog.Infof("running %s container", containerName)
-		cmd := fmt.Sprintf(cmdPrefix, containerName, "/usr/share/bcc/tools/execsnoop -n docker -l ps")
-		if _, err := c.SSH(m, cmd); err != nil {
-			c.Fatalf("unable to run SSH command '%s': %v", cmd, err)
+	// filter commands with `docker ps`
+	plog.Infof("running %s container", containerName)
+	cmd := fmt.Sprintf(cmdPrefix, containerName, "/usr/share/bcc/tools/execsnoop -n docker -l ps")
+	if _, err := c.SSH(m, cmd); err != nil {
+		c.Fatalf("unable to run SSH command '%s': %v", cmd, err)
+	}
+
+	// wait for the container and the `execsnoop` command to be correctly started before
+	// generating traffic.
+	if err := util.Retry(10, 2*time.Second, func() error {
+
+		// Run 'docker ps' to trigger log output. Execsnoop won't print anything, not even the header,
+		// efore it's been triggered for the first time.
+		_ = c.MustSSH(m, "docker ps")
+
+		// we first assert that the container is running and then the process too.
+		// it's not possible to use `docker top...` command because it's the execsnoop itself who takes some time to start.
+		logs, err := c.SSH(m, fmt.Sprintf("sudo cat $(docker inspect --format='{{.LogPath}}' %s)", containerName))
+		if err != nil {
+			return fmt.Errorf("getting running process: %w", err)
 		}
 
-		// wait for the container and the `execsnoop` command to be correctly started before
-		// generating traffic.
-		if err := util.Retry(10, 2*time.Second, func() error {
-			_ = c.MustSSH(m, "docker ps")
-
-			// we first assert that the container is running and then the process too.
-			// it's not possible to use `docker top...` command because it's the execsnoop itself who takes some time to start.
-			logs, err := c.SSH(m, fmt.Sprintf("sudo cat $(docker inspect --format='{{.LogPath}}' %s)", containerName))
-			if err != nil {
-				return fmt.Errorf("getting running process: %w", err)
-			}
-
-			if len(logs) > 0 {
-				return nil
-			}
-
-			return fmt.Errorf("no logs, the service has not started yet properly")
-		}); err != nil {
-			c.Fatalf("unable to get container ready: %v", err)
+		if len(logs) > 0 {
+			return nil
 		}
 
-		// generate some "traffic"
-		_ = c.MustSSH(m, "docker info")
-		_ = c.MustSSH(m, fmt.Sprintf("docker logs %s", containerName))
-		_ = c.MustSSH(m, fmt.Sprintf("docker top %s", containerName))
+		return fmt.Errorf("no logs, the service has not started yet properly")
+	}); err != nil {
+		c.Fatalf("unable to get container ready: %v", err)
+	}
 
-		plog.Infof("getting logs from %s container", containerName)
+	// generate some "traffic"
+	_ = c.MustSSH(m, "docker info")
+	_ = c.MustSSH(m, fmt.Sprintf("docker logs %s", containerName))
+	_ = c.MustSSH(m, fmt.Sprintf("docker top %s", containerName))
+
+
+	plog.Infof("getting logs from %s container", containerName)
+	if err := util.Retry(10, 2*time.Second, func() error {
 		logs, err := c.SSH(m, fmt.Sprintf("sudo cat $(docker inspect --format='{{.LogPath}}' %s)", containerName))
 		if err != nil {
 			c.Fatalf("unable to run SSH command: %v", err)
 		}
+		dockerLogs:= bytes.Split(logs, []byte("\n"))
 
-		l := Log{}
-		dockerLogs := bytes.Split(logs, []byte("\n"))
-		if len(dockerLogs) != 3 {
-			// we have the headers of the table
-			// then 2 lines for docker ps and the torcx call
-			c.Fatalf("docker logs should hold 3 values. Got: %d", len(dockerLogs))
+		// we have the headers of the table
+		// then 2 lines for docker ps and the torcx call if torcx is used
+		if len(dockerLogs) < 2 {
+			return fmt.Errorf("Waiting for execsnoop log entries")
 		}
 
-		execFound := false
+		l := Log{}
 		for _, log := range dockerLogs {
-			if len(log) == 0 {
-				continue
-			}
 
 			if err := json.Unmarshal(log, &l); err != nil {
-				c.Fatalf("unable to unmarshal log: %v", err)
+				return fmt.Errorf("Transient error unmarshalling docker log: %v", err)
 			}
-			plog.Infof("handling log %v", l)
-
 			if l.Stream == "stderr" {
-				c.Fatal("stream should not log to 'stderr'")
+				return fmt.Errorf("Transient error: stream should not log to 'stderr'")
 			}
-
 			if strings.Contains(l.Log, "docker info") || strings.Contains(l.Log, "docker top") || strings.Contains(l.Log, "docker logs") {
 				c.Fatal("log should not contain 'docker info' or 'docker top' or 'docker logs'")
 			}
 
 			if strings.Contains(l.Log, "docker ps") {
-				execFound = true
+				return nil
 			}
 		}
-
-		if !execFound {
-			c.Fatal("did not get 'docker ps' in the logs")
-		}
-	})
+		return fmt.Errorf("Waiting for execsnoop log entries")
+	}); err != nil {
+		c.Fatalf("Unable to find 'docker ps' log lines in execsnoop logs: %v", err)
+	}
 }

--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -63,7 +63,7 @@ func execsnoopTest(c cluster.TestCluster) {
 	if err := util.Retry(10, 2*time.Second, func() error {
 
 		// Run 'docker ps' to trigger log output. Execsnoop won't print anything, not even the header,
-		// efore it's been triggered for the first time.
+		// before it's been triggered for the first time.
 		_ = c.MustSSH(m, "docker ps")
 
 		// we first assert that the container is running and then the process too.

--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -79,8 +79,5 @@ storage:
 
 func dockerEnable(c cluster.TestCluster) {
 	m := c.Machines()[0]
-	output := c.MustSSH(m, `systemctl is-enabled docker`)
-	if string(output) != "enabled" {
-		c.Errorf("expected enabled, got %v", output)
-	}
+        c.AssertCmdOutputContains(m, "systemctl is-enabled docker", "enabled")
 }

--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // This test originated as torcx test and is kept to shield against
 // similar activation issues with sysext.
 
@@ -37,8 +36,8 @@ func init() {
 		Run:         dockerEnable,
 		ClusterSize: 1,
 		// This test is normally not related to the cloud environment
-		Platforms: []string{"qemu", "qemu-unpriv"},
-		Name:      "docker.enable-service.torcx",
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		Name:       "docker.enable-service.torcx",
 		EndVersion: semver.Version{Major: 3745},
 		UserData: conf.Butane(`
 variant: flatcar
@@ -55,8 +54,8 @@ systemd:
 		Run:         dockerEnable,
 		ClusterSize: 1,
 		// This test is normally not related to the cloud environment
-		Platforms: []string{"qemu", "qemu-unpriv"},
-		Name:      "docker.enable-service.sysext",
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		Name:       "docker.enable-service.sysext",
 		MinVersion: semver.Version{Major: 3746},
 		UserData: conf.Butane(`
 variant: flatcar

--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -1,0 +1,87 @@
+// Copyright 2017 CoreOS, Inc.
+// Copyright 2023 The Flatcar Maintainers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// This test originated as torcx test and is kept to shield against
+// similar activation issues with sysext.
+
+// The test ensures that, given respective user configuration, Docker is started
+// at boot (instead just socket-activated). This is necessary for auto-restarting
+// containers at boot that have been running at shutodwn. That's done by docker,
+// so docker must be running.
+
+package docker
+
+import (
+	"github.com/coreos/go-semver/semver"
+	"github.com/flatcar/mantle/kola/cluster"
+	"github.com/flatcar/mantle/kola/register"
+	"github.com/flatcar/mantle/platform/conf"
+)
+
+func init() {
+	// Regression test for https://github.com/coreos/bugs/issues/2079
+	register.Register(&register.Test{
+		Run:         dockerEnable,
+		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Name:      "docker.enable-service.torcx",
+		EndVersion: semver.Version{Major: 3745},
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
+systemd:
+  units:
+  - name: docker.service
+    enabled: true
+`),
+		Distros: []string{"cl"},
+	})
+
+	register.Register(&register.Test{
+		Run:         dockerEnable,
+		ClusterSize: 1,
+		// This test is normally not related to the cloud environment
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Name:      "docker.enable-service.sysext",
+		MinVersion: semver.Version{Major: 3746},
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
+systemd:
+  units:
+  - name: docker.service
+    enabled: true
+storage:
+  links:
+  - path: /etc/systemd/system/multi-user.target.wants/docker.service
+    target: /usr/lib/systemd/system/docker.service
+    hard: false
+    overwrite: true
+`),
+		// TODO FIXME: Convert this to a multi-user.target.upholds/docker.service symlink
+		// after we switch to systemd-254.
+		Distros: []string{"cl"},
+	})
+}
+
+func dockerEnable(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	output := c.MustSSH(m, `systemctl is-enabled docker`)
+	if string(output) != "enabled" {
+		c.Errorf("expected enabled, got %v", output)
+	}
+}

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -37,12 +37,9 @@ func init() {
 		ExcludePlatforms: []string{"do"},
 		Distros:          []string{"cl"},
 		// This test is normally not related to the cloud environment
-		Platforms: []string{"qemu", "qemu-unpriv"},
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		EndVersion: semver.Version{Major: 3745},
 		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
-			// Releases after 3745 don't ship torcx at all (these use sysext)
-			if (0 < version.Compare(semver.Version{Major: 3745})) {
-				return true
-			}
 			// LTS (3033) does not have the network-kargs service pulled in:
 			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
 			// Let's skip this test for < 3034 on ESX.

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -39,10 +39,10 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
-            // Releases after 3745 don't ship torcx at all (these use sysext)
-            if ( 0 < version.Compare(semver.Version{Major: 3745}) ) {
-                return true
-            }
+			// Releases after 3745 don't ship torcx at all (these use sysext)
+			if (0 < version.Compare(semver.Version{Major: 3745})) {
+				return true
+			}
 			// LTS (3033) does not have the network-kargs service pulled in:
 			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
 			// Let's skip this test for < 3034 on ESX.

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -39,6 +39,10 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+            // Releases after 3745 don't ship torcx at all (these use sysext)
+            if ( 0 < version.Compare(semver.Version{Major: 3745}) ) {
+                return true
+            }
 			// LTS (3033) does not have the network-kargs service pulled in:
 			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446
 			// Let's skip this test for < 3034 on ESX.

--- a/kola/tests/sysext/disable_containerd.go
+++ b/kola/tests/sysext/disable_containerd.go
@@ -29,12 +29,17 @@ func init() {
 		Name:        "sysext.disable-containerd",
 		// Only releases after 3745 ship sysext
 		MinVersion: semver.Version{Major: 3746},
+		// We also disable our vendor docker sysext since it depends on the containerd sysext.
 		UserData: conf.Butane(`
 variant: flatcar
 version: 1.0.0
 storage:
   links:
   - path: /etc/extensions/containerd-flatcar.raw
+    target: /dev/null
+    hard: false
+    overwrite: true
+  - path: /etc/extensions/docker-flatcar.raw
     target: /dev/null
     hard: false
     overwrite: true

--- a/kola/tests/sysext/disable_containerd.go
+++ b/kola/tests/sysext/disable_containerd.go
@@ -35,7 +35,7 @@ variant: flatcar
 version: 1.0.0
 storage:
   links:
-  - path: /etc/extensions/app-containers_containerd.raw
+  - path: /etc/extensions/containerd-flatcar.raw
     target: /dev/null
     hard: false
     overwrite: true

--- a/kola/tests/sysext/disable_containerd.go
+++ b/kola/tests/sysext/disable_containerd.go
@@ -1,16 +1,5 @@
 // Copyright 2023 The Flatcar Maintainers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sysext
 
@@ -51,7 +40,7 @@ storage:
 func containerdDisable(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	output := c.MustSSH(m,
-		`test ! -f /usr/bin/containerd || echo "ERROR"`)
+		`test -f /usr/bin/containerd && echo "ERROR" || true`)
 	if string(output) == "ERROR" {
 		c.Errorf("/usr/bin/containerd exists even when sysext is disabled!")
 	}

--- a/kola/tests/sysext/disable_containerd.go
+++ b/kola/tests/sysext/disable_containerd.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package sysext
 
 import (
@@ -26,9 +25,9 @@ func init() {
 	register.Register(&register.Test{
 		Run:         containerdDisable,
 		ClusterSize: 1,
-		Platforms: []string{"qemu", "qemu-unpriv"},
-		Name:      "sysext.disable-containerd",
-        // Only releases after 3745 ship sysext
+		Platforms:   []string{"qemu", "qemu-unpriv"},
+		Name:        "sysext.disable-containerd",
+		// Only releases after 3745 ship sysext
 		MinVersion: semver.Version{Major: 3746},
 		UserData: conf.Butane(`
 variant: flatcar
@@ -47,7 +46,7 @@ storage:
 func containerdDisable(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	output := c.MustSSH(m,
-            `test ! -f /usr/bin/containerd || echo "ERROR"`)
+		`test ! -f /usr/bin/containerd || echo "ERROR"`)
 	if string(output) == "ERROR" {
 		c.Errorf("/usr/bin/containerd exists even when sysext is disabled!")
 	}

--- a/kola/tests/sysext/disable_docker.go
+++ b/kola/tests/sysext/disable_docker.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package sysext
 
 import (
@@ -26,9 +25,9 @@ func init() {
 	register.Register(&register.Test{
 		Run:         dockerDisable,
 		ClusterSize: 1,
-		Platforms: []string{"qemu", "qemu-unpriv"},
-		Name:      "sysext.disable-docker",
-        // Only releases after 3745 ship sysext
+		Platforms:   []string{"qemu", "qemu-unpriv"},
+		Name:        "sysext.disable-docker",
+		// Only releases after 3745 ship sysext
 		MinVersion: semver.Version{Major: 3746},
 		UserData: conf.Butane(`
 variant: flatcar
@@ -47,7 +46,7 @@ storage:
 func dockerDisable(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	output := c.MustSSH(m,
-            `test ! -f /usr/bin/docker || echo "ERROR"`)
+		`test ! -f /usr/bin/docker || echo "ERROR"`)
 	if string(output) == "ERROR" {
 		c.Errorf("/usr/bin/docker exists even when sysext is disabled!")
 	}

--- a/kola/tests/sysext/disable_docker.go
+++ b/kola/tests/sysext/disable_docker.go
@@ -35,7 +35,7 @@ variant: flatcar
 version: 1.0.0
 storage:
   links:
-  - path: /etc/extensions/app-containers_docker.raw
+  - path: /etc/extensions/docker-flatcar.raw
     target: /dev/null
     hard: false
     overwrite: true

--- a/kola/tests/sysext/disable_docker.go
+++ b/kola/tests/sysext/disable_docker.go
@@ -1,16 +1,5 @@
 // Copyright 2023 The Flatcar Maintainers.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sysext
 
@@ -46,7 +35,7 @@ storage:
 func dockerDisable(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	output := c.MustSSH(m,
-		`test ! -f /usr/bin/docker || echo "ERROR"`)
+		`test -f /usr/bin/docker && echo "ERROR" || true`)
 	if string(output) == "ERROR" {
 		c.Errorf("/usr/bin/docker exists even when sysext is disabled!")
 	}

--- a/kola/tests/sysext/disable_docker.go
+++ b/kola/tests/sysext/disable_docker.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Flatcar Maintainers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package sysext
+
+import (
+	"github.com/coreos/go-semver/semver"
+	"github.com/flatcar/mantle/kola/cluster"
+	"github.com/flatcar/mantle/kola/register"
+	"github.com/flatcar/mantle/platform/conf"
+)
+
+func init() {
+	register.Register(&register.Test{
+		Run:         dockerDisable,
+		ClusterSize: 1,
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Name:      "sysext.disable-docker",
+        // Only releases after 3745 ship sysext
+		MinVersion: semver.Version{Major: 3746},
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+  - path: /etc/extensions/app-containers_docker.raw
+    target: /dev/null
+    hard: false
+    overwrite: true
+`),
+		Distros: []string{"cl"},
+	})
+}
+
+func dockerDisable(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	output := c.MustSSH(m,
+            `test ! -f /usr/bin/docker || echo "ERROR"`)
+	if string(output) == "ERROR" {
+		c.Errorf("/usr/bin/docker exists even when sysext is disabled!")
+	}
+}

--- a/kola/tests/sysext/sysext.go
+++ b/kola/tests/sysext/sysext.go
@@ -227,6 +227,7 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3603},
+		EndVersion: semver.Version{Major: 3745},
 		UserData: conf.ContainerLinuxConfig(`storage:
   files:
     - path: /etc/extensions/test/usr/lib/extension-release.d/extension-release.test
@@ -240,19 +241,39 @@ func init() {
           sysext works`),
 	})
 	register.Register(&register.Test{
-		Name:        "sysext.custom-docker",
+		Name:        "sysext.custom-docker.torcx",
 		Run:         checkSysextCustomDocker,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3185},
+		EndVersion: semver.Version{Major: 3745},
 		UserData: conf.ContainerLinuxConfig(`storage:
   files:
     - path: /etc/systemd/system-generators/torcx-generator
   directories:
     - path: /etc/extensions/docker-flatcar
     - path: /etc/extensions/containerd-flatcar`),
+	})
+	register.Register(&register.Test{
+		Name:        "sysext.custom-docker.sysext",
+		Run:         checkSysextCustomDocker,
+		ClusterSize: 1,
+		Distros:     []string{"cl"},
+		// This test is normally not related to the cloud environment
+		Platforms:  []string{"qemu", "qemu-unpriv"},
+		MinVersion: semver.Version{Major: 3746},
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+  - path: /etc/extensions/docker-flatcar.raw
+    target: /dev/null
+    hard: false
+    overwrite: true
+`),
 	})
 	register.Register(&register.Test{
 		Name:        "sysext.custom-oem",

--- a/kola/tests/sysext/sysext.go
+++ b/kola/tests/sysext/sysext.go
@@ -1,7 +1,7 @@
 // Copyright The Mantle Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package systemd
+package sysext
 
 import (
 	"fmt"
@@ -199,7 +199,7 @@ storage:
 
 func init() {
 	register.Register(&register.Test{
-		Name:        "systemd.sysext.simple.old",
+		Name:        "sysext.simple.old",
 		Run:         checkSysextSimpleOld,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
@@ -220,7 +220,7 @@ func init() {
           sysext works`),
 	})
 	register.Register(&register.Test{
-		Name:        "systemd.sysext.simple",
+		Name:        "sysext.simple",
 		Run:         checkSysextSimpleNew,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
@@ -240,7 +240,7 @@ func init() {
           sysext works`),
 	})
 	register.Register(&register.Test{
-		Name:        "systemd.sysext.custom-docker",
+		Name:        "sysext.custom-docker",
 		Run:         checkSysextCustomDocker,
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
@@ -255,7 +255,7 @@ func init() {
     - path: /etc/extensions/containerd-flatcar`),
 	})
 	register.Register(&register.Test{
-		Name:        "systemd.sysext.custom-oem",
+		Name:        "sysext.custom-oem",
 		Run:         checkSysextCustomOEM,
 		ClusterSize: 0,
 		Distros:     []string{"cl"},

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -125,7 +125,7 @@ func journalUser(c cluster.TestCluster) {
 		}
 
 		if strings.Contains(string(log), "Foo") {
-			return nil;
+			return nil
 		}
 
 		return fmt.Errorf("Waiting for log output...")

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -115,9 +115,9 @@ storage:
 func journalUser(c cluster.TestCluster) {
 	if err := util.Retry(10, 2*time.Second, func() error {
 		cmd := "journalctl --user"
-		log, e := c.SSH(c.Machines()[0], cmd)
-		if e != nil {
-			return fmt.Errorf("Did not get expexted log output from '%s': %v", cmd, e)
+		log, err := c.SSH(c.Machines()[0], cmd)
+		if err != nil {
+			return fmt.Errorf("Did not get expexted log output from '%s': %v", cmd, err)
 		}
 
 		if len(log) == 0 {

--- a/kola/tests/systemd/journald.go
+++ b/kola/tests/systemd/journald.go
@@ -128,7 +128,7 @@ func journalUser(c cluster.TestCluster) {
 			return nil
 		}
 
-		return fmt.Errorf("Waiting for log output...")
+		return fmt.Errorf("Waiting for log output containing 'Foo'...")
 	}); err != nil {
 		c.Fatalf("Unable to find 'Foo' in user journal: %v", err)
 	}


### PR DESCRIPTION
This PR prepares kola for torcx deprecation. It is a prerequisite for https://github.com/flatcar/scripts/pull/1216 . 

- A new "sysext" test module has been introduced; the existing `sysext.go` has been moved there from the `systemd` module.
  - two additional tests for disabling the docker and containerd sysexts have been added there, too.
- The "torcx" test module has been removed entirely - it contained a single test (explicitly enabling docker) which needed to be extended to cover sysext docker. That test has been moved to `docker/enable_docker.go`.
- Torcx tests are made to run conditionally and will run only for major version below a certain threshold (currently up to version 3745 but this will need to be updated depending on when https://github.com/flatcar/scripts/pull/1216 gets merged).
- New sysext tests run for major versions greater than 3746 (same conditions apply)
- A number of tests have been amended to better handle sysext environments (some implicit assumptions don't hold true anymore): `kola/tests/bpf/bpf.go` and `kola/tests/systemd/journald.go`.
- `kola/cluster/cluster.go` has been extended to print SSH commands before execution (log level INFO) and command output after execution (log level DEBUG).

## How to use

- build the container: `docker build -t my-mantle-container .`
- Check out the torcx deprecation WIP branch https://github.com/flatcar/scripts/tree/contrib/torcx-deprecation-docker-sysext
- build packages, image, and qemu_uefi VM
- edit `sdk_container/.repo/manifests/mantle-container` and put in `my-mantle-container`
- Run `./run_local_test.sh`

Note that the `sysext.custom-oem` test may still fail - it tries to download a devcontainer which might not exist for your particular image version.

## Testing done

- Built a mantle container and ran the full suite of tests locally (see "How to use" above) on an AMD64 OS image built from the latest `torcx-deprecation-docker-sysext` branch.