### PR TITLE
kola: bump torcx deprecation major release number

### DIFF
--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -36,9 +36,10 @@ func init() {
 		Run:         dockerEnable,
 		ClusterSize: 1,
 		// This test is normally not related to the cloud environment
-		Platforms:  []string{"qemu", "qemu-unpriv"},
-		Name:       "docker.enable-service.torcx",
-		EndVersion: semver.Version{Major: 3745},
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		Name:      "docker.enable-service.torcx",
+		// Torcx was retired after release 3760.
+		EndVersion: semver.Version{Major: 3760},
 		UserData: conf.Butane(`
 variant: flatcar
 version: 1.0.0
@@ -79,5 +80,5 @@ storage:
 
 func dockerEnable(c cluster.TestCluster) {
 	m := c.Machines()[0]
-        c.AssertCmdOutputContains(m, "systemctl is-enabled docker", "enabled")
+	c.AssertCmdOutputContains(m, "systemctl is-enabled docker", "enabled")
 }

--- a/kola/tests/docker/torcx_manifest_pkgs.go
+++ b/kola/tests/docker/torcx_manifest_pkgs.go
@@ -37,8 +37,9 @@ func init() {
 		ExcludePlatforms: []string{"do"},
 		Distros:          []string{"cl"},
 		// This test is normally not related to the cloud environment
-		Platforms:  []string{"qemu", "qemu-unpriv"},
-		EndVersion: semver.Version{Major: 3745},
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		// Torcx was retired after release 3760.
+		EndVersion: semver.Version{Major: 3760},
 		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
 			// LTS (3033) does not have the network-kargs service pulled in:
 			// https://github.com/flatcar/coreos-overlay/pull/1848/commits/9e04bc12c3c7eb38da05173dc0ff7beaefa13446

--- a/kola/tests/sysext/disable_containerd.go
+++ b/kola/tests/sysext/disable_containerd.go
@@ -16,8 +16,10 @@ func init() {
 		ClusterSize: 1,
 		Platforms:   []string{"qemu", "qemu-unpriv"},
 		Name:        "sysext.disable-containerd",
-		// Only releases after 3745 ship sysext
-		MinVersion: semver.Version{Major: 3746},
+		// Sysext containerd was introduced after release 3760.
+		// NOTE that 3761 is a developer version which was never released.
+		// However, the next largest Alpha major release shipped sysext.
+		MinVersion: semver.Version{Major: 3761},
 		// We also disable our vendor docker sysext since it depends on the containerd sysext.
 		UserData: conf.Butane(`
 variant: flatcar

--- a/kola/tests/sysext/disable_docker.go
+++ b/kola/tests/sysext/disable_docker.go
@@ -16,8 +16,10 @@ func init() {
 		ClusterSize: 1,
 		Platforms:   []string{"qemu", "qemu-unpriv"},
 		Name:        "sysext.disable-docker",
-		// Only releases after 3745 ship sysext
-		MinVersion: semver.Version{Major: 3746},
+		// Sysext docker was introduced after release 3760.
+		// NOTE that 3761 is a developer version which was never released.
+		// However, the next largest Alpha major release shipped sysext.
+		MinVersion: semver.Version{Major: 3761},
 		UserData: conf.Butane(`
 variant: flatcar
 version: 1.0.0

--- a/kola/tests/sysext/sysext.go
+++ b/kola/tests/sysext/sysext.go
@@ -227,7 +227,6 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3603},
-		EndVersion: semver.Version{Major: 3745},
 		UserData: conf.ContainerLinuxConfig(`storage:
   files:
     - path: /etc/extensions/test/usr/lib/extension-release.d/extension-release.test
@@ -248,7 +247,8 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3185},
-		EndVersion: semver.Version{Major: 3745},
+		// Torcx was retired after release 3760.
+		EndVersion: semver.Version{Major: 3760},
 		UserData: conf.ContainerLinuxConfig(`storage:
   files:
     - path: /etc/systemd/system-generators/torcx-generator
@@ -262,8 +262,11 @@ func init() {
 		ClusterSize: 1,
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
-		Platforms:  []string{"qemu", "qemu-unpriv"},
-		MinVersion: semver.Version{Major: 3746},
+		Platforms: []string{"qemu", "qemu-unpriv"},
+		// Sysext docker was introduced after release 3760.
+		// NOTE that 3761 is a developer version which was never released.
+		// However, the next largest Alpha major release shipped sysext.
+		MinVersion: semver.Version{Major: 3761},
 		UserData: conf.Butane(`
 variant: flatcar
 version: 1.0.0


### PR DESCRIPTION
I forgot to update the Flatcar major release versions in which torcx would be deprecated before merging https://github.com/flatcar/mantle/pull/465 . This PR fixes that; it uses today's major release 3760 as cut-off point for torcx specific tests.