### PR TITLE
.github/workflow: removing trailing spaces in calico manifest

### DIFF
--- a/.github/workflows/sync-calico-version.sh
+++ b/.github/workflows/sync-calico-version.sh
@@ -36,10 +36,12 @@ files=( $(git grep 'Source: https://raw\.githubusercontent\.com/projectcalico/ca
 # - download the new manifest
 new_link="https://raw.githubusercontent.com/projectcalico/calico/${calico_version}/manifests/custom-resources.yaml"
 wget "${new_link}"
+sed -i 's/[[:space:]]*$//' custom-resources.yaml
 mv custom-resources.yaml throw-away/custom-resources-new.yaml
 # - download the old version of manifest
 old_link=$(git grep -nA1 -e 'cat << EOF > calico.yaml' -- kola/tests/kubeadm/templates.go | tail -n 1 | sed -e 's/^.*Source: //')
 wget "${old_link}"
+sed -i 's/[[:space:]]*$//' custom-resources.yaml
 mv custom-resources.yaml throw-away/custom-resources-old.yaml
 # - for each of the using files do
 for file in "${files[@]}"; do


### PR DESCRIPTION
it happens that manifest have trailing space at the end of the key/value. The diff wants to remove the trailing space so it fails when applying the generated patch.

---

Noticed the issue here: https://github.com/flatcar/mantle/pull/467

The github action is failing since a while (see: https://github.com/flatcar/mantle/actions/workflows/sync-calico-version.yml) because of this -> the images are not mirrored. Tested with https://github.com/flatcar/mantle/actions/runs/6560916156/job/17819529865