### PR TITLE
kola: support docker in portage stable, add support for docker 24

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -142,11 +142,24 @@ passwd:
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 		// Note: copied verbatim from https://github.com/coreos/docs/blob/master/os/mounting-storage.md#creating-and-mounting-a-btrfs-volume-file
-		UserData: conf.ContainerLinuxConfig(`
+		// Added explicit btrfs driver selection because overlay2 is the default for btrfs FS in docker 23 and above
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+  - path: /etc/docker/daemon.json
+    contents:
+      inline: |
+        {
+          "storage-driver": "btrfs"
+        }
+
 systemd:
   units:
     - name: format-var-lib-docker.service
-      enable: true
+      enabled: true
       contents: |
         [Unit]
         Before=docker.service var-lib-docker.mount
@@ -158,7 +171,7 @@ systemd:
         [Install]
         WantedBy=multi-user.target
     - name: var-lib-docker.mount
-      enable: true
+      enabled: true
       contents: |
         [Unit]
         Before=docker.service

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -286,8 +286,8 @@ func kubeadmBaseTest(c cluster.TestCluster, params map[string]interface{}) {
 	}
 
 	c.Run("node readiness", func(c cluster.TestCluster) {
-		// we let some times to the cluster to be fully booted
-		if err := util.Retry(10, 10*time.Second, func() error {
+		// Wait up to 3 min (36*5 = 180s) for nginx. The test can be flaky on overcommitted platforms.
+		if err := util.Retry(36, 5*time.Second, func() error {
 			// notice the extra space before "Ready", it's to not catch
 			// "NotReady" nodes
 			out := c.MustSSH(kubectl, "/opt/bin/kubectl get nodes | grep \" Ready\"| wc -l")
@@ -307,7 +307,8 @@ func kubeadmBaseTest(c cluster.TestCluster, params map[string]interface{}) {
 			c.Fatalf("unable to deploy nginx: %v", err)
 		}
 
-		if err := util.Retry(10, 10*time.Second, func() error {
+		// Wait up to 3 min (36*5 = 180s) for nginx. The test can be flaky on overcommitted platforms.
+		if err := util.Retry(36, 5*time.Second, func() error {
 			out := c.MustSSH(kubectl, "/opt/bin/kubectl get deployments -o json | jq '.items | .[] | .status.readyReplicas'")
 			readyCnt := string(out)
 			if readyCnt != "1" {

--- a/kola/tests/sysext/sysext.go
+++ b/kola/tests/sysext/sysext.go
@@ -276,6 +276,10 @@ storage:
     target: /dev/null
     hard: false
     overwrite: true
+  - path: /etc/extensions/containerd-flatcar.raw
+    target: /dev/null
+    hard: false
+    overwrite: true
 `),
 	})
 	register.Register(&register.Test{
@@ -333,7 +337,7 @@ func checkSysextCustomDocker(c cluster.TestCluster) {
 	// First assert that Docker doesn't work because Torcx is disabled
 	_ = c.MustSSH(c.Machines()[0], cmdNotWorking)
 	// We build a custom sysext image locally because we don't host them somewhere yet
-	_ = c.MustSSH(c.Machines()[0], `git clone https://github.com/flatcar/sysext-bakery.git && git -C sysext-bakery checkout e68d2fe25c8412f4774477d1d75c40f615145c46`)
+	_ = c.MustSSH(c.Machines()[0], `git clone https://github.com/flatcar/sysext-bakery.git && git -C sysext-bakery checkout 9850ffd5b2353f45a9b3bf4fb84f8138a149e3e7`)
 	// Flatcar has no mksquashfs and btrfs is missing a bugfix but at least ext4 works
 	// The first test is for a fixed Docker version, which with the time will get old and older but is still expected to work because users may also "freeze" their Docker version this way
 	_ = c.MustSSH(c.Machines()[0], fmt.Sprintf(`ARCH=%[1]s ONLY_DOCKER=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh 20.10.21 docker && ARCH=%[1]s ONLY_CONTAINERD=1 FORMAT=ext4 sysext-bakery/create_docker_sysext.sh 20.10.21 containerd && sudo mv docker.raw containerd.raw /etc/extensions/`, arch))


### PR DESCRIPTION
This PR contains fixes for tests to add support for testing docker version 24. Docker 24 changes a number of defaults that cause issues with tests.

Required for https://github.com/flatcar/scripts/pull/1305, part of https://github.com/flatcar/Flatcar/issues/1091.