### PR TITLE
docker: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
 # Explicitly using an docker.io/amd64/ image to avoid binary translation (assuming the build host is amd64)
-# golang:1.20 is based on debian:12, this is important to ensure we have libc compatibility for the copied binary
-FROM --platform=linux/amd64 docker.io/amd64/golang:1.20 as builder-amd64
+#
+# golang:1.21-bookworm is based on debian:bookworm, this is important to ensure we have libc compatibility for the copied binary
+
+FROM --platform=linux/amd64 docker.io/amd64/golang:1.21-bookworm as builder-amd64
 # We use dynamic linking when possible to reduce compile time and binary size
 ENV CGO_ENABLED=1
 COPY . /usr/src/mantle
 # Build both here because variable builder names (to avoid caching and reusing the wrong one) are only supported with buildkit
 RUN bash -c 'cd /usr/src/mantle && ./build ; mv bin bin-amd64 ; CGO_ENABLED=0 GOARCH=arm64 ./build ; mv bin bin-arm64'
 
-# See comment above about golang:1.20 why debian:12 is set here
-FROM docker.io/library/debian:12
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y qemu-utils qemu-system-x86 qemu-system-aarch64 qemu-efi-aarch64 seabios ovmf lbzip2 sudo dnsmasq gnupg2 git curl iptables nftables dns-root-data ca-certificates sqlite3 jq awscli azure-cli
+# See comment above about golang:1.21-bookworm why debian:bookworm is set here
+FROM docker.io/library/debian:bookworm
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
-RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && curl -fsSLo /etc/apt/trusted.gpg.d/cloud.google.gpg https://dl.k8s.io/apt/doc/apt-key.gpg && apt-get update -y && apt-get install --no-install-recommends -y python3 && apt-get install -y google-cloud-cli
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc && apt-get update -y && apt-get install google-cloud-sdk -y
 COPY --from=builder-amd64 /usr/src/mantle/bin-amd64 /usr/local/bin-amd64
 COPY --from=builder-amd64 /usr/src/mantle/bin-arm64 /usr/local/bin-arm64
 RUN bash -c 'if [ "$(uname -m)" == "x86_64" ]; then rm -rf /usr/local/bin /usr/local/bin-arm64 ; mv /usr/local/bin-amd64 /usr/local/bin ; else rm -rf /usr/local/bin /usr/local/bin-amd64 ; mv /usr/local/bin-arm64 /usr/local/bin ; fi'


### PR DESCRIPTION
With 452 it currently fails to build ARM64 Docker image:
```
38.77 Preparing to unpack .../google-cloud-cli_452.0.0-0_all.deb ...
38.78 Unpacking google-cloud-cli (452.0.0-0) ...
95.90 Setting up google-cloud-cli (452.0.0-0) ...
96.76 /usr/bin/gcloud: 206: exec: python: not found
96.80 dpkg: error processing package google-cloud-cli (--configure):
96.80  installed google-cloud-cli package post-installation script subprocess returned error exit status 127
96.82 Errors were encountered while processing:
96.82  google-cloud-cli
```

