### PR TITLE
docker: use CLC for Torcx test

### DIFF
--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -40,9 +40,7 @@ func init() {
 		Name:      "docker.enable-service.torcx",
 		// Torcx was retired after release 3760.
 		EndVersion: semver.Version{Major: 3760},
-		UserData: conf.Butane(`
-variant: flatcar
-version: 1.0.0
+		UserData: conf.ContainerLinuxConfig(`
 systemd:
   units:
   - name: docker.service


### PR DESCRIPTION
This test still needs to run on flatcar-3033 LTS (which does not support Ignition 3 / Butane configuration)

---

Locally tested with current Beta (3745.1.0) and LTS 3033 from https://github.com/flatcar/scripts/pull/1307