### PR TITLE
kubeadm: update download links

### DIFF
--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -89,7 +89,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubeadm
+          url: https://dl.k8s.io/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubeadm
           verification:
             hash:
               function: sha512
@@ -99,7 +99,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubelet
+          url: https://dl.k8s.io/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubelet
           verification:
             hash:
               function: sha512
@@ -191,7 +191,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubeadm
+          url: https://dl.k8s.io/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubeadm
           verification:
             hash:
               function: sha512
@@ -201,7 +201,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubelet
+          url: https://dl.k8s.io/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubelet
           verification:
             hash:
               function: sha512
@@ -211,7 +211,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubectl
+          url: https://dl.k8s.io/release/{{ .Release }}/bin/linux/{{ .Arch }}/kubectl
           verification:
             hash:
               function: sha512

--- a/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
@@ -61,7 +61,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubeadm
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubeadm
           verification:
             hash:
               function: sha512
@@ -71,7 +71,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubelet
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubelet
           verification:
             hash:
               function: sha512
@@ -81,7 +81,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl
           verification:
             hash:
               function: sha512

--- a/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
@@ -61,7 +61,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/arm64/kubeadm
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/arm64/kubeadm
           verification:
             hash:
               function: sha512
@@ -71,7 +71,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/arm64/kubelet
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/arm64/kubelet
           verification:
             hash:
               function: sha512
@@ -81,7 +81,7 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/arm64/kubectl
+          url: https://dl.k8s.io/release/v1.21.0/bin/linux/arm64/kubectl
           verification:
             hash:
               function: sha512


### PR DESCRIPTION
`storage.googleapis` was initially used, then `dl.k8s.io` was a redirect to `storage.googleapis`.
Now `dl.k8s.io` redirects to `cdn.dl.k8s.io` - let's use this link.