### PR TITLE
docker: fix some issues with LTS 2022

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -143,13 +143,11 @@ passwd:
 		Platforms: []string{"qemu", "qemu-unpriv"},
 		// Note: copied verbatim from https://github.com/coreos/docs/blob/master/os/mounting-storage.md#creating-and-mounting-a-btrfs-volume-file
 		// Added explicit btrfs driver selection because overlay2 is the default for btrfs FS in docker 23 and above
-		UserData: conf.Butane(`
-variant: flatcar
-version: 1.0.0
-
+		UserData: conf.ContainerLinuxConfig(`
 storage:
   files:
   - path: /etc/docker/daemon.json
+    filesystem: root
     contents:
       inline: |
         {
@@ -159,7 +157,7 @@ storage:
 systemd:
   units:
     - name: format-var-lib-docker.service
-      enabled: true
+      enable: true
       contents: |
         [Unit]
         Before=docker.service var-lib-docker.mount
@@ -171,7 +169,7 @@ systemd:
         [Install]
         WantedBy=multi-user.target
     - name: var-lib-docker.mount
-      enabled: true
+      enable: true
       contents: |
         [Unit]
         Before=docker.service


### PR DESCRIPTION
*  docker: skip new device mapper test for LTS 2022 
* docker: revert config to CLC to continue testing LTS2022 

Locally tested with LTS 2022:
```
1..1
ok - docker.btrfs-storage
```