### PR TITLE
workflow: add additional images to mirror

### DIFF
--- a/.github/workflows/mirror-calico-images.sh
+++ b/.github/workflows/mirror-calico-images.sh
@@ -19,6 +19,8 @@ images=(
   calico/cni
   calico/node
   calico/kube-controllers
+  calico/csi
+  calico/node-driver-registrar
 )
 
 # we iterate over the images we want to mirror


### PR DESCRIPTION
Noticed in the calico logs:
```
pod_workers.go:965] "Error syncing pod, skipping" err="[failed to \"StartContainer\" for \"calico-csi\" with ImagePullBackOff: \"Back-off pulling image \\\"ghcr.io/flatcar/calico/csi:v3.26.3\\\"\", failed to \"StartContainer\" for \"csi-node-driver-registrar\" with ImagePullBackOff: \"Back-off pulling image \\\"ghcr.io/flatcar/calico/node-driver-registrar:v3.26.3\\\"\"]" pod="calico-system/csi-node-driver-gdhcm" podUID=05b7a8ec-7d12-486a-b6a2-87388a502d4a
```

https://github.com/projectcalico/calico/commit/9d39763ccaf9dd6ee19b0fa168fc49d410b66315 might be related? But not sure since it's present since the release 3.25.0

That should help reducing the flaky tests.