### PR TITLE
wip: Enable SELinux as early as possible

### DIFF
--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -30,7 +30,7 @@ const (
 	NoSSHKeyInUserData      Flag = iota // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata                  // don't add SSH key to platform metadata
 	NoEmergencyShellCheck               // don't check console output for emergency shell invocation
-	NoEnableSelinux                     // don't enable selinux when starting or rebooting a machine
+	NoEnableSelinux                     // don't enable selinux
 	NoKernelPanicCheck                  // don't check console output for kernel panic
 	NoVerityCorruptionCheck             // don't check console output for verity corruption
 	NoDisableUpdates                    // don't disable usage of the public update server

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -191,6 +191,15 @@ func (bc *BaseCluster) RenderUserData(userdata *conf.UserData, ignitionVars map[
 		conf.CopyKeys(keys)
 	}
 
+	if !bc.rconf.NoEnableSelinux {
+		conf.AddFile("/etc/flatcar/update.conf", "root", `SELINUX=enforcing
+SELINUXTYPE=mcs
+`, 0644)
+		// These files used to be deleted but empty files should work, too
+		conf.AddFile("/etc/audit/rules.d/80-selinux.rules", "root", ``, 0644)
+		conf.AddFile("/etc/audit/rules.d/99-default.rules", "root", ``, 0644)
+	}
+
 	// disable the public update server by default
 	if !bc.rconf.NoDisableUpdates {
 		conf.AddFile("/etc/flatcar/update.conf", "root", `SERVER=disabled

--- a/platform/util.go
+++ b/platform/util.go
@@ -81,22 +81,6 @@ func Manhole(m Machine) error {
 	return nil
 }
 
-// Enable SELinux on a machine (skip on machines without SELinux support)
-func EnableSelinux(m Machine) error {
-	_, stderr, err := m.SSH("sudo setenforce 1")
-	if err != nil {
-		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
-	}
-
-	// remove audit rules to get SELinux AVCs in the audit logs
-	_, stderr, err = m.SSH("sudo rm -rf /etc/audit/rules.d/{80-selinux.rules,99-default.rules}; sudo systemctl restart audit-rules")
-	if err != nil {
-		return fmt.Errorf("unable to enable SELinux audit logs: %s: %s", err, stderr)
-	}
-
-	return nil
-}
-
 // Reboots a machine, stopping ssh first.
 // Afterwards run CheckMachine to verify the system is back and operational.
 func StartReboot(m Machine) error {
@@ -128,11 +112,6 @@ func StartMachine(m Machine, j *Journal) error {
 	}
 	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
-	}
-	if !m.RuntimeConf().NoEnableSelinux {
-		if err := EnableSelinux(m); err != nil {
-			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
TODO: Needs kola cmdline flag to either enable selinux via ignition (new way) or at runtime (old way), so that we can pass in from the new scripts branches but not from the old


## How to use


## Testing done


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
