### PR TITLE
iovisor/bcc: add Docker image build/push workflow

### DIFF
--- a/.github/workflows/build-push-iovisor-bcc.yaml
+++ b/.github/workflows/build-push-iovisor-bcc.yaml
@@ -1,0 +1,47 @@
+name: Build and push iovisor/bcc ubuntu 22.04
+on:
+  workflow_dispatch:
+    inputs:
+      ghcr_org:
+        type: string
+        required: false
+        default: flatcar
+        description: |
+          The name of the GitHub org where the docker images should be pushed.
+
+permissions:
+  contents: read
+
+jobs:
+  build_and_push:
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ader1990/bcc
+        ref: fix_debian_changelog
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to GitHub Container Registry (ghcr)
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push image
+      id: docker_build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./docker/Dockerfile.ubuntu
+        platforms: linux/amd64,linux/arm64/v8
+        push: true
+        tags: ghcr.io/${{ inputs.ghcr_org }}/bcc:latest

--- a/kola/tests/bpf/bpf.go
+++ b/kola/tests/bpf/bpf.go
@@ -16,7 +16,7 @@ import (
 )
 
 // cmdPrefix is a temporary hack to pull `bcc` tools into Flatcar
-const cmdPrefix = "docker run -d --name %s -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf --privileged --net host --pid host quay.io/iovisor/bcc %s"
+const cmdPrefix = "docker run -d --name %s -v /lib/modules:/lib/modules -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/fs/bpf:/sys/fs/bpf --privileged --net host --pid host ghcr.io/flatcar/bcc %s"
 
 var (
 	plog = capnslog.NewPackageLogger("github.com/flatcar/mantle", "kola/tests/bpf")
@@ -40,8 +40,6 @@ func init() {
 		// required while SELinux policy is not correcly updated to support
 		// `bpf` and `perfmon` permission.
 		Flags: []register.Flag{register.NoEnableSelinux},
-		// exclude `arm64` while `quay.io/iovisor/bcc` does not have `arm64` support.
-		Architectures: []string{"amd64"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 	})


### PR DESCRIPTION
  * Added .github/workflows/build-push-iovisor-bcc.yaml workflow to build and push the image to ghcr.io/flatcar/bcc:latest
  * Switch to the ghcr.io/flatcar/bcc:latest image instead of the quay.io/iovisor/bcc image

 Until PR https://github.com/iovisor/bcc/pull/4845 is merged or the issue https://github.com/iovisor/bcc/issues/4842 is addressed, we need to use the branch with required fix to changelog and python3 modules.