### PR TITLE
kola: Pin falco driver loader to 0.36.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN bash -c 'cd /usr/src/mantle && ./build ; mv bin bin-amd64 ; CGO_ENABLED=0 GO
 
 # See comment above about golang:1.21-bookworm why debian:bookworm is set here
 FROM docker.io/library/debian:bookworm
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y apt-transport-https awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.asc] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.asc && apt-get update -y && apt-get install google-cloud-sdk -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-cli -y
 COPY --from=builder-amd64 /usr/src/mantle/bin-amd64 /usr/local/bin-amd64
 COPY --from=builder-amd64 /usr/src/mantle/bin-arm64 /usr/local/bin-arm64
 RUN bash -c 'if [ "$(uname -m)" == "x86_64" ]; then rm -rf /usr/local/bin /usr/local/bin-arm64 ; mv /usr/local/bin-amd64 /usr/local/bin ; else rm -rf /usr/local/bin /usr/local/bin-amd64 ; mv /usr/local/bin-arm64 /usr/local/bin ; fi'

--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -22,8 +22,8 @@ func init() {
 
 func loadFalco(c cluster.TestCluster) {
 	// load the falco binary
-	// TODO: first supported version will be 0.33.0, but use master tag for now
-	c.MustSSH(c.Machines()[0], "docker run --rm --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:master")
+	// TODO: master or 0.37.0 is broken for Flatcar, especially when we update glibc to 2.38
+	c.MustSSH(c.Machines()[0], "docker run --rm --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:0.36.2")
 	// Build must succeed and falco must be running
 	c.MustSSH(c.Machines()[0], "dmesg | grep falco")
 	c.MustSSH(c.Machines()[0], "lsmod | grep falco")


### PR DESCRIPTION
Falco driver loader 0.37.0 or later is broken for Flatcar at the moment. The loader switched from the old bash script to a replacement implemented in falcoctl. The image is based on Alpine instead of Ubuntu and is missing a bunch of dependencies (patchelf, bash, maybe more).
