### PR TITLE
azure: Add support for using an external availability set and resource group

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -125,6 +125,7 @@ func init() {
 	bv(&kola.AzureOptions.UseIdentity, "azure-identity", false, "Use VM managed identity for authentication (default false)")
 	sv(&kola.AzureOptions.DiskController, "azure-disk-controller", "default", "Use a specific disk-controller for storage (default \"default\", also \"nvme\" and \"scsi\")")
 	sv(&kola.AzureOptions.ResourceGroup, "azure-resource-group", "", "Deploy resources in an existing resource group")
+	sv(&kola.AzureOptions.AvailabilitySet, "azure-availability-set", "", "Deploy instances with an existing availibity set")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -124,6 +124,7 @@ func init() {
 	bv(&kola.AzureOptions.UsePrivateIPs, "azure-use-private-ips", false, "Assume nodes are reachable using private IP addresses")
 	bv(&kola.AzureOptions.UseIdentity, "azure-identity", false, "Use VM managed identity for authentication (default false)")
 	sv(&kola.AzureOptions.DiskController, "azure-disk-controller", "default", "Use a specific disk-controller for storage (default \"default\", also \"nvme\" and \"scsi\")")
+	sv(&kola.AzureOptions.ResourceGroup, "azure-resource-group", "", "Deploy resources in an existing resource group")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -154,6 +154,10 @@ func New(opts *Options) (*API, error) {
 		client = management.NewAnonymousClient()
 	}
 
+	if opts.AvailabilitySet != "" && opts.ResourceGroup == "" {
+		return nil, fmt.Errorf("ResourceGroup must match AvailabilitySet")
+	}
+
 	api := &API{
 		client: client,
 		Opts:   opts,

--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -39,6 +39,13 @@ type Machine struct {
 	PublicIPName     string
 }
 
+func (a *API) getAvset() string {
+	if a.Opts.AvailabilitySet == "" {
+		return ""
+	}
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s", a.Opts.SubscriptionID, a.Opts.ResourceGroup, a.Opts.AvailabilitySet)
+}
+
 func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, ip *network.PublicIPAddress, nic *network.Interface) compute.VirtualMachine {
 	osProfile := compute.OSProfile{
 		AdminUsername: util.StrToPtr("core"),
@@ -154,6 +161,11 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI string, 
 			plog.Infof("using custom data")
 			vm.VirtualMachineProperties.OsProfile.CustomData = &ud
 		}
+	}
+
+	availabilitySetID := a.getAvset()
+	if availabilitySetID != "" {
+		vm.VirtualMachineProperties.AvailabilitySet = &compute.SubResource{ID: &availabilitySetID}
 	}
 
 	return vm

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -55,4 +55,6 @@ type Options struct {
 	UseUserData bool
 	// ResourceGroup is an existing resource group to deploy resources in.
 	ResourceGroup string
+	// AvailabilitySet is an existing availability set to deploy the instance in.
+	AvailabilitySet string
 }

--- a/platform/api/azure/options.go
+++ b/platform/api/azure/options.go
@@ -51,6 +51,8 @@ type Options struct {
 
 	// Azure Storage API endpoint suffix. If unset, the Azure SDK default will be used.
 	StorageEndpointSuffix string
-	// UseUserData can be use to enable custom data only or user-data only.
+	// UseUserData can be used to enable custom data only or user-data only.
 	UseUserData bool
+	// ResourceGroup is an existing resource group to deploy resources in.
+	ResourceGroup string
 }


### PR DESCRIPTION
An alternative approach to reusing a resource group: only store VM object in the passed resource group and all other objects go in the kola managed RG. Instances already get deleted separately from rgs at the end of the run.

This is needed to support availability set that may be pinned to a specific compute resource. VMs that are part of an availability set must share a resource group with the availability set and must share a vnet.