### PR TITLE
Fix test script for Go >=1.20

### DIFF
--- a/test
+++ b/test
@@ -24,8 +24,7 @@ trap "rm -rf _testbin/" EXIT
 pkgs=$(go list $PKG | grep -v /vendor/)
 src=$(find . -name '*.go' -not -path "./vendor/*")
 
-echo "Building tests..."
-go test -mod=vendor -i "$@" $pkgs
+echo "Building"
 go install -mod=vendor $pkgs
 
 echo "Running tests..."


### PR DESCRIPTION
go test -i is deprecated and has been removed. It no longer serves a purpose. See: https://github.com/golang/go/issues/41696