### PR TITLE
kola/tests/tang: Ignore interfaces with no IPs

### DIFF
--- a/kola/tests/devcontainer/devcontainer.go
+++ b/kola/tests/devcontainer/devcontainer.go
@@ -54,6 +54,7 @@ if [[ "${EXPECTED_VERSION}" != "${FLATCAR_RELEASE_VERSION}" ]]; then
 fi
 
 export PORTAGE_BINHOST="${PORTAGE_BINHOST}"
+export FEATURES="-ipc-sandbox -network-sandbox"
 emerge-gitclone
 emerge --getbinpkg --verbose coreos-sources
 zcat /proc/config.gz >/usr/src/linux/.config

--- a/kola/tests/misc/tang.go
+++ b/kola/tests/misc/tang.go
@@ -118,23 +118,14 @@ func init() {
 	// If this causes issues in the future, we could alternatively add another TAP interface to the bridge and let
 	// the Tang server bind to its IP. That would require the Tang setup to happen outside of these tests and
 	// introduce complexity in different parts of the code base.
-	tangPort := 8007
 	tangIP, err := getIP()
 	if err != nil {
 		fmt.Printf("failed to find IP for the Tang server to bind to: %v\n", err)
 		return
 	}
 
-	rootConfig, err := util.ExecTemplate(IgnitionConfigRootTang, map[string]string{
-		"TangIP":   fmt.Sprintf("%v", tangIP),
-		"TangPort": strconv.Itoa(tangPort),
-	})
-	if err != nil {
-		fmt.Printf("failed to execute template: %v\n", err)
-		return
-	}
 	runRootTang := func(c cluster.TestCluster) {
-		tangTest(c, tangIP, tangPort, conf.Ignition(rootConfig), "/")
+		tangTest(c, tangIP, IgnitionConfigRootTang, "/")
 	}
 	register.Register(&register.Test{
 		Run:         runRootTang,
@@ -145,16 +136,8 @@ func init() {
 		MinVersion:  semver.Version{Major: 3880},
 	})
 
-	nonRootConfig, err := util.ExecTemplate(IgnitionConfigNonRootTang, map[string]string{
-		"TangIP":   fmt.Sprintf("%v", tangIP),
-		"TangPort": strconv.Itoa(tangPort),
-	})
-	if err != nil {
-		fmt.Printf("failed to execute template: %v\n", err)
-		return
-	}
 	runNonRootTang := func(c cluster.TestCluster) {
-		tangTest(c, tangIP, tangPort, conf.Ignition(nonRootConfig), "/mnt/data")
+		tangTest(c, tangIP, IgnitionConfigNonRootTang, "/mnt/data")
 	}
 	register.Register(&register.Test{
 		Run:         runNonRootTang,
@@ -166,13 +149,23 @@ func init() {
 	})
 }
 
-func tangTest(c cluster.TestCluster, tangIP net.IP, tangPort int, userData *conf.UserData, mountpoint string) {
-	terminateTangServer, err := startTang(c, tangIP, tangPort)
+func tangTest(c cluster.TestCluster, tangIP net.IP, ignitionTemplate string, mountpoint string) {
+	terminateTangServer, tangPort, err := startTang(c, tangIP)
 	if err != nil {
 		c.Fatalf("could not start Tang server: %v", err)
 	}
-	plog.Debugf("Started tang on %s:%d", tangIP, tangPort)
+	c.Logf("Started tang on %s:%d", tangIP, tangPort)
 	defer terminateTangServer()
+
+	ignition, err := util.ExecTemplate(ignitionTemplate, map[string]string{
+		"TangIP":   fmt.Sprintf("%v", tangIP),
+		"TangPort": strconv.Itoa(tangPort),
+	})
+	if err != nil {
+		fmt.Printf("failed to execute template: %v\n", err)
+		return
+	}
+	userData := conf.Ignition(ignition)
 
 	options := platform.MachineOptions{
 		AdditionalDisks: []platform.Disk{
@@ -234,20 +227,26 @@ func getIP() (net.IP, error) {
 	return nil, errors.New("failed to find an IP of a running network interface")
 }
 
-func startTang(c cluster.TestCluster, ip net.IP, port int) (func(), error) {
+func startTang(c cluster.TestCluster, ip net.IP) (func(), int, error) {
 	keyDirectory, err := makeTangKeyDirectory()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	srv := tang.NewServer()
 	keySet, _ := tang.ReadKeys(keyDirectory)
 	srv.Keys = keySet
-	srv.Addr = fmt.Sprintf("%v:%v", ip, port)
+	srv.Addr = fmt.Sprintf("%v:0", ip)
+
+	listener, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to setup listener: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
 
 	go func() {
 		// ListenAndServe always returns a non-nil error. ErrServerClosed on graceful close
-		err := srv.ListenAndServe()
+		err := srv.Serve(listener)
 		if err != http.ErrServerClosed {
 			c.Errorf("Tang server returned error: %v", err)
 		}
@@ -260,7 +259,7 @@ func startTang(c cluster.TestCluster, ip net.IP, port int) (func(), error) {
 		}
 	}
 
-	return terminateTangServer, nil
+	return terminateTangServer, port, nil
 }
 
 func makeTangKeyDirectory() (string, error) {

--- a/kola/tests/misc/tang.go
+++ b/kola/tests/misc/tang.go
@@ -172,6 +172,7 @@ func tangTest(c cluster.TestCluster, tangIP net.IP, tangPort int, userData *conf
 	if err != nil {
 		c.Fatalf("could not start Tang server: %v", err)
 	}
+	plog.Debugf("Started tang on %s:%d", tangIP, tangPort)
 	defer terminateTangServer()
 
 	options := platform.MachineOptions{
@@ -220,6 +221,9 @@ func getIP() (net.IP, error) {
 	for _, networkInterface := range networkInterfaces {
 		addresses, err := networkInterface.Addrs()
 		if err != nil {
+			continue
+		}
+		if len(addresses) == 0 {
 			continue
 		}
 		ipAddress, ok := addresses[0].(*net.IPNet)

--- a/kola/tests/misc/tang.go
+++ b/kola/tests/misc/tang.go
@@ -3,7 +3,6 @@ package misc
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -168,7 +167,7 @@ func init() {
 }
 
 func tangTest(c cluster.TestCluster, tangIP net.IP, tangPort int, userData *conf.UserData, mountpoint string) {
-	terminateTangServer, err := startTang(tangIP, tangPort)
+	terminateTangServer, err := startTang(c, tangIP, tangPort)
 	if err != nil {
 		c.Fatalf("could not start Tang server: %v", err)
 	}
@@ -235,7 +234,7 @@ func getIP() (net.IP, error) {
 	return nil, errors.New("failed to find an IP of a running network interface")
 }
 
-func startTang(ip net.IP, port int) (func(), error) {
+func startTang(c cluster.TestCluster, ip net.IP, port int) (func(), error) {
 	keyDirectory, err := makeTangKeyDirectory()
 	if err != nil {
 		return nil, err
@@ -250,7 +249,7 @@ func startTang(ip net.IP, port int) (func(), error) {
 		// ListenAndServe always returns a non-nil error. ErrServerClosed on graceful close
 		err := srv.ListenAndServe()
 		if err != http.ErrServerClosed {
-			log.Fatalf("Tang server returned error: %v", err)
+			c.Errorf("Tang server returned error: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
We use Equinix Metal machines in our CI that have bonded network interfaces, which means we end up with nics with no ips. The tang setup code needs to handle this. We will also want to rework the code to provide tang in the same way as we do for etcd.
