### PR TITLE
Fix tang test (part 2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,3 +56,5 @@ jobs:
         platforms: linux/amd64,linux/arm64/v8
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -93,6 +93,20 @@ func (lc *LocalCluster) GetOmahaHostPort() (string, error) {
 	return net.JoinHostPort(lc.hostIP(), port), nil
 }
 
+func (lc *LocalCluster) NewListenerInsideClusterNS() (*net.Listener, error) {
+	nsExit, err := ns.Enter(lc.flight.nshandle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enter cluster ns: %w", err)
+	}
+	defer nsExit()
+	addr := fmt.Sprintf("%s:%d", lc.hostIP(), 0)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup listener: %w", err)
+	}
+	return &listener, nil
+}
+
 func (lc *LocalCluster) NewTap(bridge string) (*TunTap, error) {
 	nsExit, err := ns.Enter(lc.flight.nshandle)
 	if err != nil {


### PR DESCRIPTION
Fix the tang test by moving the tang listener into the qemu network namespace.

Also an attempt to speed up container build so the second commit will be pushed after the first build completes.