### PR TITLE
fix check for systemd-timesyncd.service

### DIFF
--- a/kola/tests/bpf/local-gadget.go
+++ b/kola/tests/bpf/local-gadget.go
@@ -123,7 +123,7 @@ func localGadgetTest(c cluster.TestCluster) {
 
 	tmpl, err := template.New("user-data").Parse(config)
 	if err != nil {
-		c.Fatalf("parsing user-data: %w", err)
+		c.Fatalf("parsing user-data: %v", err)
 	}
 
 	c.Run("dns gadget", func(c cluster.TestCluster) {
@@ -133,7 +133,7 @@ func localGadgetTest(c cluster.TestCluster) {
 
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, gadget); err != nil {
-			c.Fatalf("rendering user-data: %w", err)
+			c.Fatalf("rendering user-data: %v", err)
 		}
 
 		node, err := c.NewMachine(conf.ContainerLinuxConfig(buf.String()))

--- a/kola/tests/ostree/basic.go
+++ b/kola/tests/ostree/basic.go
@@ -212,7 +212,7 @@ func ostreeRemoteTest(c cluster.TestCluster) {
 		osRemoteListSplit := strings.Split(string(osRemoteListOut), "\n")
 		// should have original remote + newly added remote
 		if len(osRemoteListSplit) != initialRemotesNum+1 {
-			c.Fatalf(`Did not find expected amount of ostree remotes: %q. Expected %d`, string(osRemoteListOut), osRemoteListSplit)
+			c.Fatalf(`Did not find expected amount of ostree remotes: %q. Expected %d`, string(osRemoteListOut), len(osRemoteListSplit))
 		}
 
 		var remoteFound bool = false

--- a/kola/tests/ostree/unlock.go
+++ b/kola/tests/ostree/unlock.go
@@ -252,7 +252,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 		}
 
 		if rollbackStatus.Deployments[0].Unlocked != "none" {
-			c.Fatalf(`Rollback did not remove hotfix mode; got: $q`, rollbackStatus.Deployments[0].Unlocked)
+			c.Fatalf(`Rollback did not remove hotfix mode; got: %q`, rollbackStatus.Deployments[0].Unlocked)
 		}
 
 		_, secCmdErr := c.SSH(m, ("command -v " + rpmName))

--- a/kola/tests/rpmostree/deployments.go
+++ b/kola/tests/rpmostree/deployments.go
@@ -330,7 +330,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 		// check the metadata to make sure everything went well
 		if len(postUninstallStatus.Deployments) != 2 {
-			c.Fatal("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
+			c.Fatalf("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
 		}
 
 		if postUninstallStatus.Deployments[0].Checksum != originalCsum {

--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -113,6 +113,10 @@ func init() {
         inline: |
           [Service]
           ExecStart=/bin/echo "should be deleted because its part of the Azure OEM cleanup paths"
+systemd:
+  units:
+    - name: chronyd.service
+      mask: true
 `),
 	})
 	register.Register(&register.Test{


### PR DESCRIPTION
systemd-timesyncd.service will not be the only ntp implementation enabled by default on all platforms, so the test needs to take that into account.