### PR TITLE
gce: Update default options

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -155,10 +155,10 @@ func init() {
 	sv(&kola.ExternalOptions.DeprovisioningCmds, "external-deprovisioning-cmds", "", "External platform deprovisioning commands ran on management SSH host. Has access to the variable IPADDR to identify the node.")
 
 	// gce-specific options
-	sv(&kola.GCEOptions.Image, "gce-image", "projects/coreos-cloud/global/images/family/coreos-alpha", "GCE image, full api endpoints names are accepted if resource is in a different project")
+	sv(&kola.GCEOptions.Image, "gce-image", "projects/kinvolk-public/global/images/family/flatcar-alpha", "GCE image, full api endpoints names are accepted if resource is in a different project")
 	sv(&kola.GCEOptions.Project, "gce-project", "flatcar-212911", "GCE project name")
 	sv(&kola.GCEOptions.Zone, "gce-zone", "us-central1-a", "GCE zone name")
-	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")
+	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "t2d-standard-1", "GCE machine type")
 	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")
 	sv(&kola.GCEOptions.Network, "gce-network", "default", "GCE network")
 	bv(&kola.GCEOptions.GVNIC, "gce-gvnic", false, "Use gVNIC instead of default virtio-net network device")

--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -85,7 +85,7 @@ func init() {
 }
 
 func defaultBucketNameForRegion(region string) string {
-	return fmt.Sprintf("coreos-dev-ami-import-%s", region)
+	return fmt.Sprintf("flatcar-kola-ami-import-%s", region)
 }
 
 func defaultUploadFile() string {

--- a/cmd/ore/gcloud/gcloud.go
+++ b/cmd/ore/gcloud/gcloud.go
@@ -42,7 +42,7 @@ func init() {
 	sv(&opts.Image, "image", "", "image name")
 	sv(&opts.Project, "project", "flatcar-212911", "project")
 	sv(&opts.Zone, "zone", "us-central1-a", "zone")
-	sv(&opts.MachineType, "machinetype", "n1-standard-1", "machine type")
+	sv(&opts.MachineType, "machinetype", "t2d-standard-1", "machine type")
 	sv(&opts.DiskType, "disktype", "pd-ssd", "disk type")
 	sv(&opts.BaseName, "basename", "kola", "instance name prefix")
 	sv(&opts.Network, "network", "default", "network name")

--- a/cmd/ore/gcloud/upload.go
+++ b/cmd/ore/gcloud/upload.go
@@ -234,7 +234,7 @@ func writeFile(api *storage.Service, bucket, filename, destname string) error {
 		Name:        destname,
 		ContentType: "application/x-gzip",
 	})
-	req.PredefinedAcl("authenticatedRead")
+	req.PredefinedAcl("projectPrivate")
 	req.Media(file)
 
 	if _, err := req.Do(); err != nil {


### PR DESCRIPTION
Some image/project/bucket names still reference coreos, switch to the correct flatcar values. n1-standard-1 instances are old and slightly more expensive than t2d-standard-1 so make those the default. We have also enabled "public access restriction" on our test bucket, so to get `ore gcloud upload` to work we need to switch the default object ACL to projectPrivate.