### PR TITLE
kola: write EquinixMetal metro property

### DIFF
--- a/cmd/kola/kola.go
+++ b/cmd/kola/kola.go
@@ -190,6 +190,7 @@ func writeProps() error {
 	}
 	type EquinixMetal struct {
 		Facility              string `json:"facility"`
+		Metro                 string `json:"metro"`
 		Plan                  string `json:"plan"`
 		InstallerImageBaseURL string `json:"installer"`
 		ImageURL              string `json:"image"`
@@ -256,6 +257,7 @@ func writeProps() error {
 		},
 		EquinixMetal: EquinixMetal{
 			Facility:              kola.EquinixMetalOptions.Facility,
+			Metro:                 kola.EquinixMetalOptions.Metro,
 			Plan:                  kola.EquinixMetalOptions.Plan,
 			InstallerImageBaseURL: kola.EquinixMetalOptions.InstallerImageBaseURL,
 			ImageURL:              kola.EquinixMetalOptions.ImageURL,


### PR DESCRIPTION
This property was not provided to the `properties.json` resulting in an empty field: http://bincache.flatcar-linux.net/testing/3913.0.0/amd64/equinix_metal/_kola_temp/equinixmetal-latest/properties.json

I personally never used this file but for consistency we should add the `metro` field.

Closes: https://github.com/flatcar/Flatcar/issues/1408