### PR TITLE
kola: Increase amount of disk corruption in verity test

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -96,8 +96,8 @@ func VerityCorruption(c cluster.TestCluster) {
 	// get usr device, probably vda3
 	usrdev := util.GetUsrDeviceNode(c, m)
 
-	// write zero bytes to first 10 MB
-	c.MustSSH(m, fmt.Sprintf(`sudo dd if=/dev/zero of=%s bs=1M count=10 status=none`, usrdev))
+	// write zero bytes to first 100 MB
+	c.MustSSH(m, fmt.Sprintf(`sudo dd if=/dev/zero of=%s bs=1M count=100 status=none`, usrdev))
 
 	// make sure we flush everything so the filesystem has to go through to the device backing verity before fetching a file from /usr
 	// (done in one execution because after flushing command itself runs the corruption could already be detected,


### PR DESCRIPTION
For a particular image build the filesystem seemed to be more resistant to the corruption test, be it due to the corruption hitting other structures or some non-flushable cache covering more of the corrupted area. One can still trigger the verity panic by overwriting 100 MB instead of 10 MB.
Increase the amount of zeros written by the corruption test.

## How to use


## Testing done

Tested with the amd64 image here https://bincache.flatcar-linux.net/images/amd64/9999.9.9+kai-remove-acbuild/flatcar_production_image.bin.bz2 which was able to avoid the direct panic on the 10 MB corruption due to caching effects.