### PR TITLE
platform/api/azure: Switch gallery API version to 2022-08-03

### DIFF
--- a/platform/api/azure/gallery-image-template.json
+++ b/platform/api/azure/gallery-image-template.json
@@ -45,7 +45,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2022-08-01",
+      "apiVersion": "2022-08-03",
       "location": "[parameters('location')]",
       "name": "[parameters('galleries_name')]",
       "properties": {
@@ -54,7 +54,7 @@
       "type": "Microsoft.Compute/galleries"
     },
     {
-      "apiVersion": "2022-08-01",
+      "apiVersion": "2022-08-03",
       "dependsOn": [
         "[resourceId('Microsoft.Compute/galleries', parameters('galleries_name'))]"
       ],
@@ -90,7 +90,7 @@
       "type": "Microsoft.Compute/galleries/images"
     },
     {
-      "apiVersion": "2022-08-01",
+      "apiVersion": "2022-08-03",
       "dependsOn": [
         "[resourceId('Microsoft.Compute/galleries/images', parameters('galleries_name'), parameters('image_name'))]",
         "[resourceId('Microsoft.Compute/galleries', parameters('galleries_name'))]"


### PR DESCRIPTION
Followup for: https://github.com/flatcar/mantle/pull/517
I tested that PR with an externally created gallery, and didn't test the gallery creation itself, so I missed this detail.

Surprisingly API version 2022-08-01 does not exist for the galleries resource provider. The SDK uses 2022-01-01 even when we import 2022-08-01. Since we use an ARM template for gallery creation, we have to manually select the correct api version, otherwise gallery creation fails.

The error I get is:
> 2024-04-05T12:27:49Z ore/azure: Couldn't create gallery image: Code="DeploymentFailed" Message="At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details." Details=[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"NoRegisteredProviderFound\",\r\n    \"message\": \"No registered resource provider found for location 'eastus' and API version '2022-08-01' for type 'galleries'. The supported api-versions are '2018-06-01, 2019-03-01, 2019-07-01, 2019-12-01, 2020-09-30, 2021-03-01, 2021-07-01, 2021-10-01, 2022-01-03, 2022-03-03, 2022-08-03, 2023-07-03'. The supported locations are 'westcentralus, southcentralus, eastus2, southeastasia, westeurope, westus, eastus, canadacentral, northeurope, northcentralus, brazilsouth, ukwest, westindia, eastasia, australiaeast, japaneast, koreasouth, westus2, canadaeast, uksouth, centralindia, southindia, australiasoutheast, japanwest, koreacentral, francecentral, centralus, australiacentral, southafricanorth, uaenorth, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest, westus3, swedencentral, qatarcentral, polandcentral, italynorth, israelcentral, eastus2euap, centraluseuap'.\"\r\n  }\r\n}"}]
