### PR TITLE
kola: Shorten TPM test name to keep the socket path under the limit

### DIFF
--- a/kola/tests/misc/tpm.go
+++ b/kola/tests/misc/tpm.go
@@ -252,18 +252,19 @@ func init() {
 		Run:         runRootTPMCryptenroll,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-cryptenroll",
+		Name:        "cl.tpm.root-ce",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})
 	runRootTPMCryptenrollPcrNoUpdate := func(c cluster.TestCluster) {
 		tpmTest(c, IgnitionConfigRootCryptenrollPcrNoUpdate, "/", VariantNoUpdate)
 	}
+	// The test names are part of the UNIX socket path which is limited to 108 chars
 	register.Register(&register.Test{
 		Run:         runRootTPMCryptenrollPcrNoUpdate,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-cryptenroll-pcr-noupdate",
+		Name:        "cl.tpm.root-ce-pcr-noupd",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})
@@ -274,7 +275,7 @@ func init() {
 		Run:         runRootTPMCryptenrollPcrWithUpdate,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-cryptenroll-pcr-withupdate",
+		Name:        "cl.tpm.root-ce-pcr-w-upd",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})

--- a/platform/local/tpm.go
+++ b/platform/local/tpm.go
@@ -20,7 +20,7 @@ func NewSwtpm(dir string) (*SoftwareTPM, error) {
 
 	os.Mkdir(dir, 0700)
 	swtpm.dir = dir
-	swtpm.socketPath = fmt.Sprintf("%v/sock", swtpm.dir)
+	swtpm.socketPath = fmt.Sprintf("%v/sk", swtpm.dir)
 
 	swtpm.process = exec.Command("swtpm", "socket", "--tpmstate", fmt.Sprintf("dir=%v", swtpm.dir), "--ctrl", fmt.Sprintf("type=unixio,path=%v", swtpm.socketPath), "--tpm2")
 	out, err := swtpm.process.StderrPipe()


### PR DESCRIPTION
The TPM directory is created under the _kola_temp folder for the VM. In total the path used for the swtpm socket was above the 108 char limit for some tests.
Shorten the affected test names to keep the socket path under the limit.


## How to use

Rerun Jenkins tests with this

## Testing done

Tests passed for [qemu on amd64](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/21808/console) and [qemu_uefi on arm64](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/21809/console)
