### PR TITLE
kola: Run qemu and swtpm with the machine folder as working dir

### DIFF
--- a/kola/tests/misc/tpm.go
+++ b/kola/tests/misc/tpm.go
@@ -252,19 +252,18 @@ func init() {
 		Run:         runRootTPMCryptenroll,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-ce",
+		Name:        "cl.tpm.root-cryptenroll",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})
 	runRootTPMCryptenrollPcrNoUpdate := func(c cluster.TestCluster) {
 		tpmTest(c, IgnitionConfigRootCryptenrollPcrNoUpdate, "/", VariantNoUpdate)
 	}
-	// The test names are part of the UNIX socket path which is limited to 108 chars
 	register.Register(&register.Test{
 		Run:         runRootTPMCryptenrollPcrNoUpdate,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-ce-pcr-noupd",
+		Name:        "cl.tpm.root-cryptenroll-pcr-noupdate",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})
@@ -275,7 +274,7 @@ func init() {
 		Run:         runRootTPMCryptenrollPcrWithUpdate,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
-		Name:        "cl.tpm.root-ce-pcr-w-upd",
+		Name:        "cl.tpm.root-cryptenroll-pcr-withupdate",
 		Distros:     []string{"cl"},
 		MinVersion:  semver.Version{Major: 3913, Minor: 0, Patch: 1},
 	})

--- a/platform/local/cluster.go
+++ b/platform/local/cluster.go
@@ -40,8 +40,8 @@ type LocalCluster struct {
 	OmahaServer OmahaWrapper
 }
 
-func (lc *LocalCluster) NewCommand(name string, arg ...string) exec.Cmd {
-	cmd := ns.Command(lc.flight.nshandle, name, arg...)
+func (lc *LocalCluster) NewCommand(dir string, name string, arg ...string) exec.Cmd {
+	cmd := ns.CommandWithDir(&dir, lc.flight.nshandle, name, arg...)
 	return cmd
 }
 

--- a/platform/local/configdrive.go
+++ b/platform/local/configdrive.go
@@ -22,10 +22,11 @@ import (
 )
 
 // MakeConfigDrive creates a config drive directory tree under outputDir
-// and returns the path to the top level directory.
+// and returns the sub dir path to the top level directory, relative to
+// outputDir.
 func MakeConfigDrive(userdata *conf.Conf, outputDir string) (string, error) {
-	drivePath := path.Join(outputDir, "config-2")
-	userPath := path.Join(drivePath, "openstack/latest/user_data")
+	drivePath := "config-2"
+	userPath := path.Join(outputDir, drivePath, "openstack/latest/user_data")
 
 	if err := os.MkdirAll(path.Dir(userPath), 0777); err != nil {
 		os.RemoveAll(drivePath)

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -16,6 +16,7 @@ package qemu
 
 import (
 	"io/ioutil"
+	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
 
@@ -32,6 +33,7 @@ type machine struct {
 	journal     *platform.Journal
 	consolePath string
 	console     string
+	subDir      string
 	swtpm       *local.SoftwareTPM
 }
 
@@ -76,7 +78,7 @@ func (m *machine) Destroy() {
 	}
 	m.journal.Destroy()
 
-	if buf, err := ioutil.ReadFile(m.consolePath); err == nil {
+	if buf, err := ioutil.ReadFile(filepath.Join(m.subDir, m.consolePath)); err == nil {
 		m.console = string(buf)
 	} else {
 		plog.Errorf("Error reading console for instance %v: %v", m.ID(), err)

--- a/system/ns/exec.go
+++ b/system/ns/exec.go
@@ -26,8 +26,16 @@ type Cmd struct {
 }
 
 func Command(ns netns.NsHandle, name string, arg ...string) *Cmd {
+	return CommandWithDir(nil, ns, name, arg...)
+}
+
+func CommandWithDir(dir *string, ns netns.NsHandle, name string, arg ...string) *Cmd {
+	cmd := exec.Command(name, arg...)
+	if dir != nil {
+		cmd.Dir = *dir
+	}
 	return &Cmd{
-		ExecCmd:  exec.Command(name, arg...),
+		ExecCmd:  cmd,
 		NsHandle: ns,
 	}
 }


### PR DESCRIPTION
The long UNIX socket path caused problems and the workaround was to shorten the test names but a real solution is to ensure that the path is always short. This can be done by setting the current working directory for the swtpm process to the machine folder which also holds the socket and, in addition, setting the current working directory for the qemu process to the same folder. Then we can use 'tpm/socket' as path which is ensured to be below the limit of 108 characters.


## How to use


## Testing done

Tests [passed on GitHub Actions](https://github.com/flatcar/scripts/actions/runs/8705614424?pr=1908) in this [test PR](https://github.com/flatcar/scripts/pull/1908)