### PR TITLE
kola/tests/falco: Pass kmod to driver loader

### DIFF
--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -22,7 +22,7 @@ func init() {
 
 func loadFalco(c cluster.TestCluster) {
 	// load the falco binary
-	c.MustSSH(c.Machines()[0], "docker run --rm --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:master")
+	c.MustSSH(c.Machines()[0], "docker run --rm --privileged -v /root/.falco:/root/.falco -v /proc:/host/proc:ro -v /boot:/host/boot:ro -v /lib/modules:/host/lib/modules:ro -v /usr:/host/usr:ro -v /etc:/host/etc:ro falcosecurity/falco-driver-loader:master kmod")
 	// Build must succeed and falco must be running
 	c.MustSSH(c.Machines()[0], "dmesg | grep falco")
 	c.MustSSH(c.Machines()[0], "lsmod | grep falco")


### PR DESCRIPTION
The driver-loader switched to using "modern_ebpf" mode by default, but lets continue testing kmod.