### PR TITLE
kola: Fix path for qemu-bios argument

### DIFF
--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -132,7 +132,11 @@ ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
 
 	// This uses path arguments with path values being
 	// relative to the folder created for this machine
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
+	biosImage, err := filepath.Abs(qc.flight.opts.BIOSImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize bios path: %v", err)
+	}
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, biosImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -145,7 +145,11 @@ LinkLocalAddressing=no
 	}
 	// This uses path arguments with path values being
 	// relative to the folder created for this machine
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, qc.flight.opts.BIOSImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
+	biosImage, err := filepath.Abs(qc.flight.opts.BIOSImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize bios path: %v", err)
+	}
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, biosImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/system/exec/exec.go
+++ b/system/exec/exec.go
@@ -55,13 +55,25 @@ type ExecCmd struct {
 }
 
 func Command(name string, arg ...string) *ExecCmd {
-	return CommandContext(context.Background(), name, arg...)
+	return CommandWithDir(nil, name, arg...)
+}
+
+func CommandWithDir(dir *string, name string, arg ...string) *ExecCmd {
+	return CommandContextWithDir(dir, context.Background(), name, arg...)
 }
 
 func CommandContext(ctx context.Context, name string, arg ...string) *ExecCmd {
+	return CommandContextWithDir(nil, ctx, name, arg...)
+}
+
+func CommandContextWithDir(dir *string, ctx context.Context, name string, arg ...string) *ExecCmd {
 	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, name, arg...)
+	if dir != nil {
+		cmd.Dir = *dir
+	}
 	return &ExecCmd{
-		Cmd:    exec.CommandContext(ctx, name, arg...),
+		Cmd:    cmd,
 		cancel: cancel,
 	}
 }


### PR DESCRIPTION
- kola: Align qemu-unpriv with qemu after new additions
    
    The qemu-unpriv platform doesn't support as many test scenarious as the
    priv. qemu platform but it is still useful for testing. When doing
    changes in the qemu platform we should also do them for qemu-unpriv.
    Port the last changes over to get swtpm support.

- kola: Fix path for qemu-bios argument
    
    After changing the qemu working directory, relative qemu-bios path
    arguments stopped working.
    Handle relative paths by prepending kola's current working directory.
    The changes from
    `git diff --no-index platform/machine/qemu/ platform/machine/unprivqemu/`
    show that only platform-specific options differ. As a test
    `cl.tpm.root-cryptenroll` passed for `--platform=qemu` and
    `--platform=qemu-unpriv` when run with
    `--qemu-bios=flatcar_production_qemu_uefi_efi_code.fd` as relative path
    argument.


## How to use

This should fix the qemu_uefi nightly failure

## Testing done

Local testing as mentioned above:
```
./kola run -d --platform=qemu-unpriv --qemu-bios=/var/tmp/flatcar_production_qemu_uefi_efi_code.fd --qemu-image /var/tmp/flatcar_production_image.bin cl.basic
./kola run -d --platform=qemu-unpriv --qemu-bios=flatcar_production_qemu_uefi_efi_code.fd --qemu-image /var/tmp/flatcar_production_image.bin cl.tpm.root-cryptenroll
sudo ./kola run -d --platform=qemu --qemu-bios=flatcar_production_qemu_uefi_efi_code.fd --qemu-image /var/tmp/flatcar_production_image.bin cl.tpm.root-cryptenroll
```
