### PR TITLE
kola: Exclude user dbus session entries from dead symbolic links check

### DIFF
--- a/kola/tests/misc/files.go
+++ b/kola/tests/misc/files.go
@@ -89,6 +89,7 @@ func DeadLinks(c cluster.TestCluster) {
 		"/run/systemd",
 		"/run/udev/links",
 		"/run/udev/watch",
+		"/run/user/500/systemd/units",
 		"/sys",
 		"/var/lib/docker",
 		"/var/lib/rkt",


### PR DESCRIPTION
After enabling the user dbus session, the dead link check fails because the path always contains dead links but that's expected behavior.

## How to use

Fixes test failure in https://github.com/flatcar/scripts/pull/1964

## Testing done

Local run passes for the built image

