### PR TITLE
kubernetes: add 1.30

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -76,6 +76,19 @@ var (
 	// testConfig holds params for various kubernetes releases
 	// and the nested params are used to render script templates
 	testConfig = map[string]map[string]interface{}{
+		"v1.30.1": map[string]interface{}{
+			"HelmVersion":     "v3.13.2",
+			"MinMajorVersion": 3374,
+			// from https://github.com/flannel-io/flannel/releases
+			"FlannelVersion": "v0.22.0",
+			// from https://github.com/cilium/cilium/releases
+			"CiliumVersion": "1.12.5",
+			// from https://github.com/cilium/cilium-cli/releases
+			"CiliumCLIVersion": "v0.12.12",
+			"DownloadDir":      "/opt/bin",
+			"PodSubnet":        "192.168.0.0/17",
+			"cgroupv1":         false,
+		},
 		"v1.29.2": map[string]interface{}{
 			"HelmVersion":     "v3.13.2",
 			"MinMajorVersion": 3374,


### PR DESCRIPTION
This PR adds Kubernetes 1.30.1 and remove EOL 1.27.6 from tested versions.

Related to: https://github.com/flatcar/flatcar-website/pull/339

Tested on Brightbox with LTS 3510.3.3:
```
$ cat _kola_temp/brightbox-latest/test.tap
1..4
ok - kubeadm.v1.30.1.cilium.base
ok - kubeadm.v1.30.1.flannel.base
ok - kubeadm.v1.30.1.calico.base
ok - kubeadm.v1.28.7.calico.cgroupv1.base
```