### PR TITLE
plume/azure: Add support for managed identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Some tests dealing with OEM partition were duplicated or adapted for the OEM partition mountpoint move. The older versions of Flatcar will run tests for the old mountpoint location, the new enough versions - for both mountpoint locations. ([#423](https://github.com/flatcar/mantle/pull/423))
 - The `systemd.sysext.custom-docker` test now tries to figure out the distributed Docker version by searching for both `app-emulation/docker` and `app-containers/docker` package information. The older versions of Flatcar use the former, the new versions will use the latter ([#438](https://github.com/flatcar/mantle/pull/438))
 - DigitalOcean now supports deleting images with the same name ([#440](https://github.com/flatcar/mantle/pull/440))
+- Add support to plume azure release and pre-release to use managed identities ([#535](https://github.com/flatcar/mantle/pull/535))
 
 ### Removed
 

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -83,6 +83,8 @@ var (
 	publishMarketplace bool
 	// username is the default user on instances launched by AWS Marketplace.
 	username string
+	// azureUseIdentity is a bool to use managed identity for authentication
+	azureUseIdentity bool
 )
 
 type imageMetadataAbstract struct {
@@ -117,6 +119,7 @@ func init() {
 	cmdPreRelease.Flags().StringVar(&azureAuth, "azure-auth", "", "Azure Credentials json file")
 	cmdPreRelease.Flags().StringVar(&azureCategory, "azure-category", "", "Azure category (empty/pro)")
 	cmdPreRelease.Flags().StringVar(&azureTestContainer, "azure-test-container", "", "Use test container instead of default")
+	cmdPreRelease.Flags().BoolVar(&azureUseIdentity, "azure-identity", false, "Use VM managed identity for authentication (default false)")
 	cmdPreRelease.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
 	cmdPreRelease.Flags().StringVar(&verifyKeyFile,
 		"verify-key", "", "path to ASCII-armored PGP public key to be used in verifying download signatures.")
@@ -314,6 +317,7 @@ func azurePreRelease(ctx context.Context, client *http.Client, src *storage.Buck
 			AzureProfile:      azureProfile,
 			AzureAuthLocation: azureAuth,
 			AzureSubscription: environment.SubscriptionName,
+			UseIdentity:       azureUseIdentity,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create Azure API: %v", err)

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -53,6 +53,7 @@ func init() {
 	cmdRelease.Flags().StringVar(&azureProfile, "azure-profile", "", "Azure Profile json file")
 	cmdRelease.Flags().StringVar(&azureAuth, "azure-auth", "", "Azure Credentials json file")
 	cmdRelease.Flags().StringVar(&azureTestContainer, "azure-test-container", "", "Use test container instead of default")
+	cmdRelease.Flags().BoolVar(&azureUseIdentity, "azure-identity", false, "Use VM managed identity for authentication (default false)")
 	cmdRelease.Flags().StringVar(&gceReleaseKey, "gce-release-key", "", "GCE key file for releases")
 	cmdRelease.Flags().BoolVarP(&releaseDryRun, "dry-run", "n", false,
 		"perform a trial run, do not make changes")
@@ -394,6 +395,7 @@ func doAzure(ctx context.Context, client *http.Client, src *storage.Bucket, spec
 			AzureProfile:      azureProfile,
 			AzureAuthLocation: azureAuth,
 			AzureSubscription: environment.SubscriptionName,
+			UseIdentity:       azureUseIdentity,
 		})
 		if err != nil {
 			plog.Fatalf("failed to create Azure API: %v", err)


### PR DESCRIPTION
Add the support to run the pre-release and the release jobs via managed idenities 

to be merged with https://github.com/flatcar/scripts/pull/2048