### PR TITLE
[wip] arm64: increase VM RAM to fix ldconfig.service crashes

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -300,6 +300,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 	// coreos-assembler folks as they utilize something
 	// similar in cosa run
 	var qmBinary string
+	vmMemSizeMB := "3072"
 	combo := runtime.GOARCH + "--" + board
 	switch combo {
 	case "amd64--amd64-usr":
@@ -308,7 +309,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "accel=kvm",
 			"-cpu", "host",
-			"-m", "2512",
+			"-m", vmMemSizeMB,
 		}
 	case "amd64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"
@@ -316,7 +317,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-aarch64",
 			"-machine", "virt",
 			"-cpu", "cortex-a57",
-			"-m", "2512",
+			"-m", vmMemSizeMB,
 		}
 	case "arm64--amd64-usr":
 		qmBinary = "qemu-system-x86_64"
@@ -324,7 +325,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "pc-q35-2.8",
 			"-cpu", "kvm64",
-			"-m", "2512",
+			"-m", vmMemSizeMB,
 		}
 	case "arm64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"
@@ -332,7 +333,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-aarch64",
 			"-machine", "virt,accel=kvm,gic-version=3",
 			"-cpu", "host",
-			"-m", "2512",
+			"-m", vmMemSizeMB,
 		}
 	default:
 		panic("host-guest combo not supported: " + combo)


### PR DESCRIPTION

Try to increase the RAM of the VMs to not have ldconfig crashes anymore.

See: https://github.com/flatcar/Flatcar/issues/1493
