### PR TITLE
kola/tests: Replace nmap's ncat with openbsd ncat

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand=
 - using `--qemu-vnc 0`, it's possible to setup a VNC server. Similar to SSH you need to identify the PID of the `qemu` instance to setup a proxy:
 ```
 mkfifo reply
-ncat -kl 12800 < reply | sudo nsenter -t "${QEMUPID}" -n ncat localhost 5900 > reply
+nc -kl 12800 < reply | sudo nsenter -t "${QEMUPID}" -n nc localhost 5900 > reply
 rm reply
 ```
 Now, you can access the VNC session on localhost:12800 using a VNC client.

--- a/kola/tests/podman/podman.go
+++ b/kola/tests/podman/podman.go
@@ -275,15 +275,15 @@ func podmanNetworkTest(c cluster.TestCluster) {
 	machines := c.Machines()
 	src, dest := machines[0], machines[1]
 
-	c.Log("creating ncat containers")
+	c.Log("creating netcat containers")
 
-	tutil.GenPodmanScratchContainer(c, src, "ncat", []string{"ncat"})
-	tutil.GenPodmanScratchContainer(c, dest, "ncat", []string{"ncat"})
+	tutil.GenPodmanScratchContainer(c, src, "netcat", []string{"timeout", "nc"})
+	tutil.GenPodmanScratchContainer(c, dest, "netcat", []string{"timeout", "nc"})
 
 	listener := func(ctx context.Context) error {
 		// Will block until a message is recieved
 		out, err := c.SSH(dest,
-			`echo "HELLO FROM SERVER" | sudo podman run -i -p 9988:9988 ncat ncat --idle-timeout 20 --listen 0.0.0.0 9988`,
+			`echo "HELLO FROM SERVER" | sudo podman run -i -p 9988:9988 netcat timeout 20 nc -l -N 0.0.0.0 9988`,
 		)
 		if err != nil {
 			return err
@@ -317,7 +317,7 @@ func podmanNetworkTest(c cluster.TestCluster) {
 			}
 		}
 
-		srcCmd := fmt.Sprintf(`echo "HELLO FROM CLIENT" | sudo podman run -i ncat ncat %s 9988`, dest.PrivateIP())
+		srcCmd := fmt.Sprintf(`echo "HELLO FROM CLIENT" | sudo podman run -i netcat nc %s 9988`, dest.PrivateIP())
 		out, err := c.SSH(src, srcCmd)
 		if err != nil {
 			return err


### PR DESCRIPTION
OpenBSD netcat has no long flags and has no idle timeout flag, so these need to be replaced with short flags and using a timeout utility, respectively.