### PR TITLE
platform/qemu: add 'qemu-vnc' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ _Note for both architectures_:
 ```shell
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="sudo nsenter -n -t <PID of the QEMU instance> nc %h %p" -p 22 core@<IP of the QEMU instance>
 ```
+- using `--qemu-vnc 0`, it's possible to setup a VNC server. Similar to SSH you need to identify the PID of the `qemu` instance to setup a proxy:
+```
+mkfifo reply
+ncat -kl 12800 < reply | sudo nsenter -t "${QEMUPID}" -n ncat localhost 5900 > reply
+rm reply
+```
+Now, you can access the VNC session on localhost:12800 using a VNC client.
 
 ##### Advanced usage with Equinix Metal
 

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -223,6 +223,7 @@ func init() {
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.BIOSImage, "qemu-bios", "", "BIOS to use for QEMU vm")
+	sv(&kola.QEMUOptions.VNC, "qemu-vnc", "", "VNC port (0 for 5900, 1 for 5901, etc.)")
 	bv(&kola.QEMUOptions.UseVanillaImage, "qemu-skip-mangle", false, "don't modify CL disk image to capture console log")
 	sv(&kola.QEMUOptions.ExtraBaseDiskSize, "qemu-grow-base-disk-by", "", "grow base disk by the given size in bytes, following optional 1024-based suffixes are allowed: b (ignored), k, K, M, G, T")
 	bv(&kola.QEMUOptions.EnableTPM, "qemu-tpm", false, "enable TPM device in QEMU. Requires installing swtpm. Use only with 'kola spawn', test cases are responsible for creating a VM with TPM explicitly.")

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -46,6 +46,7 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		// Use for 'kola spawn'; test cases should pass true through
 		// NewMachineWithOptions()
 		EnableTPM: qc.flight.opts.EnableTPM,
+		VNC:       qc.flight.opts.VNC,
 	}
 	return qc.NewMachineWithOptions(userdata, options)
 }

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -46,6 +46,9 @@ type Options struct {
 
 	EnableTPM bool
 
+	// VNC port to provide a VNC session
+	VNC string
+
 	*platform.Options
 }
 

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -38,6 +38,7 @@ type MachineOptions struct {
 	ExtraPrimaryDiskSize string
 	EnableTPM            bool
 	SoftwareTPMSocket    string
+	VNC                  string
 }
 
 type Disk struct {
@@ -373,6 +374,10 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 		qmCmd = append(qmCmd,
 			"-fsdev", "local,id=cfg,security_model=none,readonly=on,path="+confPath,
 			"-device", Virtio(board, "9p", "fsdev=cfg,mount_tag=config-2"))
+	}
+
+	if options.VNC != "" {
+		qmCmd = append(qmCmd, "-vnc", fmt.Sprintf(":%s", options.VNC))
 	}
 
 	// auto-read-only is only available in 3.1.0 & greater versions of QEMU


### PR DESCRIPTION
This option can be set to 0, 1, 2, etc. to set a QEMU VNC server on resp. port 5900, 5901, 5902, etc.

QEMU tests are running in a dedicated network namespace, to access the VNC server, you need to proxy the request.

Example:
```
mkfifo reply
ncat -kl 12800 < reply | sudo nsenter -t "${QEMUPID}" -n ncat localhost 5900 > reply
rm reply
```

Using any VNC client, you can access the VNC session on port 12800.

This can be useful when debugging booting issue (UEFI).
