### PR TITLE
go: bump to 1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # Explicitly using an docker.io/amd64/ image to avoid binary translation (assuming the build host is amd64)
 #
-# golang:1.21-bookworm is based on debian:bookworm, this is important to ensure we have libc compatibility for the copied binary
+# golang:1.22-bookworm is based on debian:bookworm, this is important to ensure we have libc compatibility for the copied binary
 
-FROM --platform=linux/amd64 docker.io/amd64/golang:1.21-bookworm as builder-amd64
+FROM --platform=linux/amd64 docker.io/amd64/golang:1.22-bookworm as builder-amd64
 # We use dynamic linking when possible to reduce compile time and binary size
 ENV CGO_ENABLED=1
 COPY . /usr/src/mantle
 # Build both here because variable builder names (to avoid caching and reusing the wrong one) are only supported with buildkit
 RUN bash -c 'cd /usr/src/mantle && ./build ; mv bin bin-amd64 ; CGO_ENABLED=0 GOARCH=arm64 ./build ; mv bin bin-arm64'
 
-# See comment above about golang:1.21-bookworm why debian:bookworm is set here
+# See comment above about golang:1.22-bookworm why debian:bookworm is set here
 FROM docker.io/library/debian:bookworm
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y apt-transport-https awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo swtpm
 # from https://cloud.google.com/storage/docs/gsutil_install#deb

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/flatcar/mantle
 
-go 1.21
-
-toolchain go1.22.2
+go 1.22.5
 
 require (
 	cloud.google.com/go/storage v1.30.1


### PR DESCRIPTION
This is required for: https://github.com/flatcar/mantle/pull/533