### PR TITLE
docker: do not run device mapper test

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -187,6 +187,7 @@ systemd:
 
 	register.Register(&register.Test{
 		MinVersion:  semver.Version{Major: 3034},
+		EndVersion:  semver.Version{Major: 4053},
 		Run:         func(c cluster.TestCluster) { testDockerInfo("devicemapper", c) },
 		ClusterSize: 1,
 		Name:        "docker.devicemapper-storage",


### PR DESCRIPTION
With Docker greater than version 25 device mapper has been removed. This should land in Flatcar from version 4053.

