### PR TITLE
locksmith: set max semaphore to 3

### DIFF
--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -152,6 +152,7 @@ func locksmithCluster(c cluster.TestCluster) {
 	}
 
 	c.MustSSH(machs[0], "locksmithctl status")
+	c.MustSSH(machs[0], "locksmithctl set-max 3")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()


### PR DESCRIPTION
With recent upgrade from Go 1.21 to Go 1.22 we noticed that this test has never run as designed.

Previously this test was rebooting only one machine while it's supposed to coordinate the reboot of 3 machines.

It was an issue with the "for" loop:

> Previously, the variables declared by a “for” loop were created
> once and updated by each iteration. In Go 1.22, each iteration
> of the loop creates new variables, to avoid accidental sharing bugs.

Now we set the maximum of token to 3, this is not recommended in production as it might create a downtime but here it's ok for testing purposes.

Race condition should not occur as there is a 5 minutes delay between the command and the actual reboot.

## Testing done

Locally on QEMU.

3 semaphore: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/25061/