### PR TITLE
docker: skip device mapper for <= 4048

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -187,7 +187,7 @@ systemd:
 
 	register.Register(&register.Test{
 		MinVersion:  semver.Version{Major: 3034},
-		EndVersion:  semver.Version{Major: 4053},
+		EndVersion:  semver.Version{Major: 4048},
 		Run:         func(c cluster.TestCluster) { testDockerInfo("devicemapper", c) },
 		ClusterSize: 1,
 		Name:        "docker.devicemapper-storage",


### PR DESCRIPTION
Otherwise nightlies will fail

--- 

Sorry for the back and forth - this "MinVersion" / "EndVersion" is often confusing me. If we set the version to 4053 the test will try to run on the nightlies until the release. 