### PR TITLE
azure: enable CustomData if the userdata has cloud-init format

### DIFF
--- a/platform/machine/azure/cluster.go
+++ b/platform/machine/azure/cluster.go
@@ -48,7 +48,7 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	instance, err := ac.flight.Api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount, ac.Network)
+	instance, err := ac.flight.Api.CreateInstance(ac.vmname(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount, conf, ac.Network)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, see: https://github.com/flatcar/Flatcar/issues/656, Flatcar on Azure does not support the Azure Virtual Machine feature AzureVM-UserData (https://learn.microsoft.com/en-us/azure/virtual-machines/user-data) enabled when the userdata is in cloud-init (cloud-config) format. It requires the Azure Virtual Machine feature called AzureVM-CustomData (https://learn.microsoft.com/en-us/azure/virtual-machines/custom-data) to be enabled. Yes, I know, confusing.

This change fixes the flakiness in the `cl.cloudinit.basic` Mantle test, which sometimes was run with AzureVMUserData enabled.

Patch made by @jepio.

Fixes: https://github.com/flatcar/Flatcar/issues/1505