### PR TITLE
azure: Update storage config following Gallery Image API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - DigitalOcean now supports deleting images with the same name ([#440](https://github.com/flatcar/mantle/pull/440))
 - Add support to plume azure release and pre-release to use managed identities ([#535](https://github.com/flatcar/mantle/pull/535))
 - Azure platform uses new go SDK, changing the way we authenticate (using azidentity now) ([#532](https://github.com/flatcar/mantle/pull/532))
+- Update storage config following Azure Compute Gallery Image API change ([#550](https://github.com/flatcar/mantle/pull/550))
 
 ### Removed
 

--- a/platform/api/azure/gallery-image-template.json
+++ b/platform/api/azure/gallery-image-template.json
@@ -115,7 +115,7 @@
           "osDiskImage": {
             "hostCaching": "ReadOnly",
             "source": {
-              "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_name'))]",
+              "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccounts_name'))]",
               "uri": "[parameters('vhd_uri')]"
             }
           }


### PR DESCRIPTION
# azure: Update storage config following API change

I was notified of a breaking API change occurring on 2024/11/05. It did not appear necessary to update the permissions in the Terraform file.

## How to use

Build Kola and deploy to Azure.

## Testing done

Tested by deploying Flatcar with Kola.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)