### PR TITLE
api/equinixmetal: allows using different port for webserver storage

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -212,6 +212,7 @@ func init() {
 	sv(&kola.EquinixMetalOptions.InstallerImageCpioURL, "equinixmetal-installer-image-cpio-url", "", "EquinixMetal installer image cpio URL, (default equinixmetal-installer-image-base-url/flatcar_production_pxe_image.cpio.gz)")
 	sv(&kola.EquinixMetalOptions.ImageURL, "equinixmetal-image-url", "", "EquinixMetal image URL (default board-dependent, e.g. \"https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_packet_image.bin.bz2\")")
 	sv(&kola.EquinixMetalOptions.StorageURL, "equinixmetal-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Storage URL for temporary uploads (supported: gs, ssh+http, ssh+https or ssh which defaults to https for download)")
+	sv(&kola.EquinixMetalOptions.StorageSSHPort, "equinixmetal-storage-ssh-port", "22", "SSH port used for the storage URL if this one uses SSH")
 	sv(&kola.EquinixMetalOptions.Metro, "equinixmetal-metro", "", "the Metro where you want your server to live")
 	sv(&kola.EquinixMetalOptions.RemoteUser, "equinixmetal-remote-user", "core", "the user for SSH connection to the remote storage")
 	sv(&kola.EquinixMetalOptions.RemoteSSHPrivateKeyPath, "equinixmetal-remote-ssh-private-key-path", "./id_rsa", "the path to SSH private key for SSH connection to the remote storage")

--- a/platform/api/equinixmetal/api.go
+++ b/platform/api/equinixmetal/api.go
@@ -103,6 +103,8 @@ type Options struct {
 	// Google Storage base URL for temporary uploads
 	// e.g. gs://users.developer.core-os.net/bovik/mantle
 	StorageURL string
+	// StorageSSHPort is the port used to SSH into the "storage" server a SSH URL is provided.
+	StorageSSHPort string
 	// Metro is where you want your server to live.
 	Metro string
 
@@ -216,7 +218,7 @@ func New(opts *Options) (*API, error) {
 			},
 		}
 
-		client, err := ssh.Dial("tcp", url.Host, cfg)
+		client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", url.Hostname(), opts.StorageSSHPort), cfg)
 		if err != nil {
 			return nil, fmt.Errorf("creating SSH client: %w", err)
 		}
@@ -235,7 +237,7 @@ func New(opts *Options) (*API, error) {
 			protocol = proto
 		}
 
-		storage = sshstorage.New(client, url.Hostname(), opts.RemoteDocumentRoot, protocol)
+		storage = sshstorage.New(client, url.Host, opts.RemoteDocumentRoot, protocol)
 	}
 
 	if opts.LaunchTimeout == 0 {


### PR DESCRIPTION
One can now provide a URL like: ssh+http://1.2.3.4:8088 to upload the temporary artifacts on server 1.2.3.4 via SSH and download the artifacts from http://1.2.3.4:8088