### PR TITLE
kola: add board->arch mapping for Hetzner

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -673,6 +673,9 @@ func architecture(pltfrm string) string {
 	if pltfrm == "azure" && AzureOptions.Board != "" {
 		nativeArch = boardToArch(AzureOptions.Board)
 	}
+	if pltfrm == "hetzner" && HetznerOptions.Board != "" {
+		nativeArch = boardToArch(HetznerOptions.Board)
+	}
 	return nativeArch
 }
 


### PR DESCRIPTION
# Fix kolet binary architecture on Hetzner

Add a mapping for `hetzner` platform so the right `kolet` binary is uploaded.

Without this, kola would always upload the amd64 kolet, even for arm64 tests.

This failed with:

    bash: line 1: ./kolet: cannot execute binary file: Exec format error

## How to use

See https://github.com/flatcar/scripts/pull/2142 for usage.

## Testing done

Tested it locally with (only important flags):

```
bin/kola --board="arm64-usr" --platform hetzner --hetzner-server-type cax11 run cl.basic
```

Which failed without these changes and succeeds now.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
