### PR TITLE
Add action for building other docker images, add a test for open-iscsi

### DIFF
--- a/.github/workflows/build-other-docker-image.yaml
+++ b/.github/workflows/build-other-docker-image.yaml
@@ -1,0 +1,52 @@
+name: Build other docker image
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "Name of the image from the other-dockerfiles directory."
+        required: true
+        type: choice
+        options:
+        - targetcli-fb
+
+env:
+  REGISTRY: ghcr.io
+  ORG: flatcar
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: other-dockerfiles/${{ inputs.image_name }}
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ inputs.image_name }}:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/kola/tests/packages/openiscsi.go
+++ b/kola/tests/packages/openiscsi.go
@@ -1,0 +1,157 @@
+package packages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/flatcar/mantle/kola/cluster"
+	"github.com/flatcar/mantle/kola/tests/util"
+	"github.com/flatcar/mantle/platform"
+)
+
+var (
+	getInitiatorClientScript = util.TrimLeftSpace(`
+#!/bin/bash
+
+set -euo pipefail
+
+sudo systemctl start iscsid
+for i in {0..9}; do
+    if [[ ! -e /etc/iscsi/initiatorname.iscsi ]]; then
+        sleep 1
+        continue
+    fi
+    name=$(grep -F InitiatorName /etc/iscsi/initiatorname.iscsi | cut -d= -f2-)
+    if [[ -z ${name} ]]; then
+        echo "malformed initiator name config"
+        exit 1
+    fi
+    echo "${name}"
+    exit 0
+done
+echo "no initiator name config found"
+exit 1
+`)
+
+	setupServerScript = util.TrimLeftSpace(`
+#!/bin/bash
+
+set -euo pipefail
+
+initiator=${1}
+
+mkdir -p /shared
+
+cat <<EOF >/shared/init.script
+cd /
+backstores/fileio create test /shared/test.img 100m
+iscsi/ create iqn.2006-04.com.example:test-target
+cd iscsi/iqn.2006-04.com.example:test-target/tpg1/
+luns/ create /backstores/fileio/test
+set attribute generate_node_acls=1
+acls/ create ${initiator}
+EOF
+
+docker_args=(
+    --privileged
+    --network host
+    --mount type=bind,source=/sys,destination=/sys
+    --mount type=bind,source=/shared,destination=/shared
+    --mount type=bind,source=/run/dbus,destination=/run/dbus,readonly
+    --mount type=bind,source=/usr/lib/modules,destination=/usr/lib/modules,readonly
+    --rm
+)
+
+docker run "${docker_args[@]}" ghcr.io/flatcar/targetcli-fb bash -c 'targetcli </shared/init.script'
+`)
+
+	discoverClientScript = util.TrimLeftSpace(`
+#!/bin/bash
+
+set -euo pipefail
+
+host_ip=${1}
+
+target=$(iscsiadm --mode=discovery --type=sendtargets --portal="${host_ip}" | cut -d' ' -f 2-)
+iscsiadm --mode=node --login --targetname="${target}" --portal="${host_ip}"
+
+for i in {0..9}; do
+    if [[ -e /dev/sda ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ ! -e /dev/sda ]]; then
+    echo "no /dev/sda device"
+    exit 1
+fi
+
+mkfs.ext2 /dev/sda
+
+mkdir -p /drive
+mount -t ext2 /dev/sda /drive
+echo "seems to be working" >/drive/test-file
+umount /drive
+
+systemctl enable iscsi
+`)
+
+	checkClientScript = util.TrimLeftSpace(`
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ ! -e /dev/sda ]]; then
+    echo "no /dev/sda device after reboot"
+    exit 1
+fi
+
+mkdir -p /drive
+mount -t ext2 /dev/sda /drive
+
+if [[ ! -e /drive/test-file ]]; then
+    echo 'expected file missing'
+    exit 1
+fi
+
+contents=$(cat /drive/test-file)
+if [[ ${contents} != 'seems to be working' ]]; then
+    echo "unexpected file contents: ${contents@Q}"
+    exit 1
+fi
+umount /drive
+`)
+)
+
+func openISCSI(c cluster.TestCluster) {
+	// machine 0 will have the remote disk mounted
+	//
+	// machine 1 will be a disk provider
+	client := c.Machines()[0]
+	server := c.Machines()[1]
+
+	for name, script := range map[string]string{
+		"/get_initiator": getInitiatorClientScript,
+		"/discover":      discoverClientScript,
+		"/check":         checkClientScript,
+	} {
+		if err := platform.InstallFile(strings.NewReader(script), client, name); err != nil {
+			c.Fatalf("failed to upload script %s to client: %v", name, err)
+		}
+	}
+	if err := platform.InstallFile(strings.NewReader(setupServerScript), server, "/setup"); err != nil {
+		c.Fatalf("failed to upload script /setup to server: %v", err)
+	}
+
+	c.MustSSH(client, "sudo chmod a+x /get_initiator /discover /check")
+	c.MustSSH(server, "sudo chmod a+x /setup")
+
+	initiatorName := c.MustSSH(client, `sudo /get_initiator`)
+	c.MustSSH(server, fmt.Sprintf("sudo /setup '%s'", initiatorName))
+	c.MustSSH(client, fmt.Sprintf("sudo /discover %s", server.PrivateIP()))
+	if err := client.Reboot(); err != nil {
+		c.Fatalf("failed to reboot the client: %v", err)
+	}
+	c.MustSSH(client, "sudo /check")
+}

--- a/kola/tests/packages/packages.go
+++ b/kola/tests/packages/packages.go
@@ -22,7 +22,7 @@ import (
 func init() {
 	register.Register(&register.Test{
 		Run:         packageTests,
-		ClusterSize: 1,
+		ClusterSize: 2,
 		Name:        "packages",
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
@@ -32,4 +32,5 @@ func init() {
 
 func packageTests(c cluster.TestCluster) {
 	c.Run("sys-cluster/ipvsadm", ipvsadm)
+	c.Run("sys-block/open-iscsi", openISCSI)
 }

--- a/other-dockerfiles/targetcli-fb/Dockerfile
+++ b/other-dockerfiles/targetcli-fb/Dockerfile
@@ -1,0 +1,5 @@
+# For this image to work /sys, /etc, /run/dbus and /usr/lib/modules
+# need to be forwarded, also needs --privileged and --network host.
+
+FROM docker.io/library/debian:bookworm-slim
+RUN apt-get update && apt-get upgrade --assume-yes && apt-get install --assume-yes --no-install-recommends kmod targetcli-fb


### PR DESCRIPTION
This PR adds a github action that can be used for building docker images based on dockerfiles stored in the `other-dockerfiles` directory. The action takes one parameter, which is a name of a subdirectory in `other-dockerfiles`. Currently there's just one, `targetcli-fb`. The action has no other triggers than workflow-dispatch. For now, the `targetcli-fb` docker image does not need to be rebuilt all that often - supposedly only when the dockerfile gets updated.

Second change is an addition of the `packages` subtest for checking the open-iscsi functionality. The test is based on steps outlined by @chewi in https://github.com/flatcar/scripts/pull/2261.

CI run for amd64: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/26905/console

The CI was running with some extra modifications in the branch, which are now gone:
- Some debugging stuff like `set -x` to the shell scripts.
- Used `ghcr.io/krnowak/targetcli-fb` instead of `ghcr.io/flatcar/targetcli-fb`, and the action was also changed to upload to my account, instead of flatcar.