### PR TITLE
support testing secureboot in Qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@ wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_productio
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_code.fd.sig
 gpg --verify flatcar_production_qemu_uefi_efi_code.fd.sig
 
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.fd
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.fd.sig
+gpg --verify flatcar_production_qemu_uefi_efi_vars.fd.sig
+
 sudo ./bin/kola run --board amd64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p qemu \
-    --qemu-bios flatcar_production_qemu_uefi_efi_code.fd \
+    --qemu-firmware flatcar_production_qemu_uefi_efi_code.fd \
+    --qemu-ovmf-vars flatcar_production_qemu_uefi_efi_vars.fd \
     --qemu-image flatcar_production_qemu_image.img \
     cl.locksmith.cluster
 ```
@@ -104,17 +109,17 @@ sudo ./bin/kola run --board amd64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p 
 ###### Run tests for ARM64
 Example with the latest `alpha` release:
 ```shell
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_secure_image.img
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_secure_image.img.sig
-gpg --verify flatcar_production_qemu_uefi_secure_image.img.sig
+wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_image.img
+wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_image.img.sig
+gpg --verify flatcar_production_qemu_uefi_image.img.sig
 
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.fd
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.fd.sig
 gpg --verify flatcar_production_qemu_uefi_efi_code.fd.sig
 
 sudo ./bin/kola run --board arm64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p qemu \
-    --qemu-bios flatcar_production_qemu_uefi_efi_code.fd \
-    --qemu-image flatcar_production_qemu_uefi_secure_image.bin \
+    --qemu-firmware flatcar_production_qemu_uefi_efi_code.fd \
+    --qemu-image flatcar_production_qemu_uefi_image.img \
     cl.etcd-member.discovery
 ```
 

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -315,6 +315,9 @@ func syncOptions() error {
 	if kola.QEMUOptions.Firmware == "" {
 		kola.QEMUOptions.Firmware = kolaDefaultFirmware[kola.QEMUOptions.Board]
 	}
+	if kola.QEMUOptions.EnableSecureboot && kola.QEMUOptions.OVMFVars == "" {
+		return fmt.Errorf("Secureboot requires OVMF vars file")
+	}
 	units, _ := root.PersistentFlags().GetStringSlice("debug-systemd-units")
 	for _, unit := range units {
 		kola.Options.SystemdDropins = append(kola.Options.SystemdDropins, platform.SystemdDropin{

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -223,6 +223,8 @@ func init() {
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
+	sv(&kola.QEMUOptions.Firmware, "qemu-bios", "", "bios to use for QEMU vm")
+	root.PersistentFlags().MarkDeprecated("qemu-bios", "use --qemu-firmware")
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "firmware image to use for QEMU vm")
 	sv(&kola.QEMUOptions.VNC, "qemu-vnc", "", "VNC port (0 for 5900, 1 for 5901, etc.)")
 	sv(&kola.QEMUOptions.OVMFVars, "qemu-ovmf-vars", "", "OVMF vars file to use for QEMU vm")

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -54,7 +54,7 @@ var (
 		"rhcos": "v3",
 	}
 
-	kolaDefaultBIOS = map[string]string{
+	kolaDefaultFirmware = map[string]string{
 		"amd64-usr": "bios-256k.bin",
 		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_code.fd",
 	}
@@ -87,6 +87,7 @@ func init() {
 	sv(&kola.UpdatePayloadFile, "update-payload", "", "Path to an update payload that should be made available to tests")
 	bv(&kola.ForceFlatcarKey, "force-flatcar-key", false, "Use the Flatcar production key to verify update payload")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
+	bv(&kola.Options.EnableSecureboot, "enable-secureboot", false, "Instantiate a Secureboot Machine")
 	iv(&kola.Options.SSHRetries, "ssh-retries", kolaSSHRetries, "Number of retries with the SSH timeout when starting the machine")
 	dv(&kola.Options.SSHTimeout, "ssh-timeout", kolaSSHTimeout, "A timeout for a single try of establishing an SSH connection when starting the machine")
 
@@ -222,8 +223,9 @@ func init() {
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
-	sv(&kola.QEMUOptions.BIOSImage, "qemu-bios", "", "BIOS to use for QEMU vm")
+	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "firmware image to use for QEMU vm")
 	sv(&kola.QEMUOptions.VNC, "qemu-vnc", "", "VNC port (0 for 5900, 1 for 5901, etc.)")
+	sv(&kola.QEMUOptions.OVMFVars, "qemu-ovmf-vars", "", "OVMF vars file to use for QEMU vm")
 	bv(&kola.QEMUOptions.UseVanillaImage, "qemu-skip-mangle", false, "don't modify CL disk image to capture console log")
 	sv(&kola.QEMUOptions.ExtraBaseDiskSize, "qemu-grow-base-disk-by", "", "grow base disk by the given size in bytes, following optional 1024-based suffixes are allowed: b (ignored), k, K, M, G, T")
 	bv(&kola.QEMUOptions.EnableTPM, "qemu-tpm", false, "enable TPM device in QEMU. Requires installing swtpm. Use only with 'kola spawn', test cases are responsible for creating a VM with TPM explicitly.")
@@ -310,8 +312,8 @@ func syncOptions() error {
 		kola.QEMUOptions.DiskImage = image
 	}
 
-	if kola.QEMUOptions.BIOSImage == "" {
-		kola.QEMUOptions.BIOSImage = kolaDefaultBIOS[kola.QEMUOptions.Board]
+	if kola.QEMUOptions.Firmware == "" {
+		kola.QEMUOptions.Firmware = kolaDefaultFirmware[kola.QEMUOptions.Board]
 	}
 	units, _ := root.PersistentFlags().GetStringSlice("debug-systemd-units")
 	for _, unit := range units {

--- a/kola/harness.go
+++ b/kola/harness.go
@@ -223,6 +223,10 @@ var (
 	}
 )
 
+func SkipSecureboot(_ semver.Version, channel, arch, platform string) bool {
+	return Options.EnableSecureboot
+}
+
 // NativeRunner is a closure passed to all kola test functions and used
 // to run native go functions directly on kola machines. It is necessary
 // glue until kola does introspection.

--- a/kola/tests/misc/falco.go
+++ b/kola/tests/misc/falco.go
@@ -1,6 +1,7 @@
 package misc
 
 import (
+	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
 )
@@ -16,7 +17,8 @@ func init() {
 		// falco builder container can't handle our arm64 config (yet)
 		Architectures: []string{"amd64"},
 		// selinux blocks insmod from within container
-		Flags: []register.Flag{register.NoEnableSelinux},
+		Flags:    []register.Flag{register.NoEnableSelinux},
+		SkipFunc: kola.SkipSecureboot,
 	})
 }
 

--- a/kola/tests/sysext/zfs.go
+++ b/kola/tests/sysext/zfs.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
 	"github.com/flatcar/mantle/platform"
@@ -133,7 +134,7 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3902},
-		SkipFunc:   skipOnGha,
+		SkipFunc:   skipZfs,
 	})
 
 	register.Register(&register.Test{
@@ -144,7 +145,7 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3902},
-		SkipFunc:   skipOnGha,
+		SkipFunc:   skipZfs,
 	})
 
 	register.Register(&register.Test{
@@ -155,8 +156,12 @@ func init() {
 		// This test is normally not related to the cloud environment
 		Platforms:  []string{"qemu", "qemu-unpriv"},
 		MinVersion: semver.Version{Major: 3902},
-		SkipFunc:   skipOnGha,
+		SkipFunc:   skipZfs,
 	})
+}
+
+func skipZfs(version semver.Version, channel, arch, platform string) bool {
+	return kola.SkipSecureboot(version, channel, arch, platform) || skipOnGha(version, channel, arch, platform)
 }
 
 func skipOnGha(version semver.Version, channel, arch, platform string) bool {

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -133,11 +133,15 @@ ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
 
 	// This uses path arguments with path values being
 	// relative to the folder created for this machine
-	biosImage, err := filepath.Abs(qc.flight.opts.BIOSImage)
+	firmware, err := filepath.Abs(qc.flight.opts.Firmware)
 	if err != nil {
-		return nil, fmt.Errorf("failed to canonicalize bios path: %v", err)
+		return nil, fmt.Errorf("failed to canonicalize firmware path: %v", err)
 	}
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, biosImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
+	ovmfVars, err := filepath.Abs(qc.flight.opts.OVMFVars)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize ovmf vars path: %v", err)
+	}
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, firmware, ovmfVars, qm.consolePath, confPath, qc.flight.diskImagePath, qc.flight.opts.EnableSecureboot, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -17,6 +17,7 @@ package qemu
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -137,10 +138,19 @@ ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
 	if err != nil {
 		return nil, fmt.Errorf("failed to canonicalize firmware path: %v", err)
 	}
-	ovmfVars, err := filepath.Abs(qc.flight.opts.OVMFVars)
-	if err != nil {
-		return nil, fmt.Errorf("failed to canonicalize ovmf vars path: %v", err)
+	ovmfVars := ""
+	if qc.flight.opts.OVMFVars != "" {
+		ovmfVars, err = platform.CreateOvmfVarsCopy(qm.subDir, qc.flight.opts.OVMFVars)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if ovmfVars != "" {
+				os.Remove(path.Join(qm.subDir, ovmfVars))
+			}
+		}()
 	}
+
 	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, firmware, ovmfVars, qm.consolePath, confPath, qc.flight.diskImagePath, qc.flight.opts.EnableSecureboot, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
@@ -185,7 +195,7 @@ ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
 
 	// from this point on Destroy() is responsible for cleaning up swtpm
 	qm.swtpm, swtpm = swtpm, nil
-
+	qm.ovmfVars, ovmfVars = ovmfVars, ""
 	plog.Debugf("qemu PID (manual cleanup needed if --remove=false): %v", qm.qemu.Pid())
 
 	if err := platform.StartMachine(qm, qm.journal); err != nil {

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -35,9 +35,12 @@ type Options struct {
 	// DiskImage is the full path to the disk image to boot in QEMU.
 	DiskImage string
 
-	// BIOSImage is name of the BIOS file to pass to QEMU.
+	// Firmware is name of the Firmware file to pass to QEMU.
 	// It can be a plain name, or a full path.
-	BIOSImage string
+	Firmware string
+
+	// OMVF Vars file to pass to QEMU UEFI
+	OVMFVars string
 
 	// Don't modify CL disk images to add console logging
 	UseVanillaImage bool

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -16,6 +16,8 @@ package qemu
 
 import (
 	"io/ioutil"
+	"os"
+	"path"
 	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
@@ -33,6 +35,7 @@ type machine struct {
 	journal     *platform.Journal
 	consolePath string
 	console     string
+	ovmfVars    string
 	subDir      string
 	swtpm       *local.SoftwareTPM
 }
@@ -75,6 +78,12 @@ func (m *machine) Destroy() {
 	}
 	if m.swtpm != nil {
 		m.swtpm.Stop()
+	}
+	if m.ovmfVars != "" {
+		err := os.Remove(path.Join(m.subDir, m.ovmfVars))
+		if err != nil {
+			plog.Errorf("Error removing OVMF vars: %v", err)
+		}
 	}
 	m.journal.Destroy()
 

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -145,11 +145,15 @@ LinkLocalAddressing=no
 	}
 	// This uses path arguments with path values being
 	// relative to the folder created for this machine
-	biosImage, err := filepath.Abs(qc.flight.opts.BIOSImage)
+	firmware, err := filepath.Abs(qc.flight.opts.Firmware)
 	if err != nil {
-		return nil, fmt.Errorf("failed to canonicalize bios path: %v", err)
+		return nil, fmt.Errorf("failed to canonicalize firmware path: %v", err)
 	}
-	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, biosImage, qm.consolePath, confPath, qc.flight.diskImagePath, conf.IsIgnition(), options)
+	ovmfVars, err := filepath.Abs(qc.flight.opts.OVMFVars)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize ovmf vars path: %v", err)
+	}
+	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, firmware, ovmfVars, qm.consolePath, confPath, qc.flight.diskImagePath, qc.flight.opts.EnableSecureboot, conf.IsIgnition(), options)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -143,15 +144,24 @@ LinkLocalAddressing=no
 			}
 		}()
 	}
+
+	ovmfVars := ""
+	if qc.flight.opts.OVMFVars != "" {
+		ovmfVars, err = platform.CreateOvmfVarsCopy(qm.subDir, qc.flight.opts.OVMFVars)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if ovmfVars != "" {
+				os.Remove(path.Join(qm.subDir, ovmfVars))
+			}
+		}()
+	}
 	// This uses path arguments with path values being
 	// relative to the folder created for this machine
 	firmware, err := filepath.Abs(qc.flight.opts.Firmware)
 	if err != nil {
 		return nil, fmt.Errorf("failed to canonicalize firmware path: %v", err)
-	}
-	ovmfVars, err := filepath.Abs(qc.flight.opts.OVMFVars)
-	if err != nil {
-		return nil, fmt.Errorf("failed to canonicalize ovmf vars path: %v", err)
 	}
 	qmCmd, extraFiles, err := platform.CreateQEMUCommand(qc.flight.opts.Board, qm.id, firmware, ovmfVars, qm.consolePath, confPath, qc.flight.diskImagePath, qc.flight.opts.EnableSecureboot, conf.IsIgnition(), options)
 	if err != nil {
@@ -186,6 +196,7 @@ LinkLocalAddressing=no
 
 	// from this point on Destroy() is responsible for cleaning up swtpm
 	qm.swtpm, swtpm = swtpm, nil
+	qm.ovmfVars, ovmfVars = ovmfVars, ""
 	plog.Debugf("qemu PID (manual cleanup needed if --remove=false): %v", qm.qemu.Pid())
 
 	pid := strconv.Itoa(qm.qemu.Pid())

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -16,6 +16,8 @@ package unprivqemu
 
 import (
 	"io/ioutil"
+	"os"
+	"path"
 	"path/filepath"
 
 	"golang.org/x/crypto/ssh"
@@ -32,6 +34,7 @@ type machine struct {
 	journal     *platform.Journal
 	consolePath string
 	console     string
+	ovmfVars    string
 	subDir      string
 	swtpm       *local.SoftwareTPM
 	ip          string
@@ -77,6 +80,12 @@ func (m *machine) Destroy() {
 
 	if m.swtpm != nil {
 		m.swtpm.Stop()
+	}
+	if m.ovmfVars != "" {
+		err := os.Remove(path.Join(m.subDir, m.ovmfVars))
+		if err != nil {
+			plog.Errorf("Error removing OVMF vars: %v", err)
+		}
 	}
 	m.journal.Destroy()
 

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -163,6 +163,9 @@ type Options struct {
 	// Board is the board used by the image
 	Board string
 
+	// Toggle to instantiate a secureboot instance.
+	EnableSecureboot bool
+
 	// How many times to retry establishing an SSH connection when
 	// creating a journal or when doing a machine check.
 	SSHRetries int

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -377,6 +377,10 @@ func CreateQEMUCommand(board, uuid, firmware, ovmfVars, consolePath, confPath, d
 			"-drive", fmt.Sprintf("if=pflash,unit=1,file=%v,format=raw", ovmfVars),
 		)
 		if enableSecureboot {
+			// When OVMF is built for X64 with SMM enabled S3 (suspend/resume)
+			// must be disabled. This is required for secure boot and not very
+			// well documented. The flag comes from here:
+			// https://github.com/tianocore/edk2/blob/b81557a00c61cc80ab118828f16ed9ce79455880/OvmfPkg/README#L213
 			qmCmd = append(qmCmd,
 				"-global", "ICH9-LPC.disable_s3=1",
 				"-global", "driver=cfi.pflash01,property=secure,value=on",


### PR DESCRIPTION
@sayanchowdhury + @jepio

* add new kola command line flags: --qemu-ovmf-vars and --enable-secureboot. --enable-secureboot will eventually be useful for other platforms as well (AWS/GCP/Azure).
* --qemu-bios has been renamed to --qemu-firmware, but --qemu-bios is kept around so that we don't break old releases if we only backport kola changes.
* ovmf vars file is copied into instance folder per test case execution
* skip falco and zfs tests when secure boot: unsigned kernel modules can't be loaded when secure boot is enabled, enforced by lockdown integrity mode.
* force boot from primary disk using `bootindex`

Tested here: http://jenkins.infra.kinvolk.io:8080/job/container/job/test_dispatcher/5120/cldsv/ with ghcr.io/flatcar/mantle:pr-554
