### PR TITLE
kubeadm: drop 1.28 and add 1.31

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -119,6 +119,7 @@ var (
 	plog       = capnslog.NewPackageLogger("github.com/flatcar/mantle", "kola/tests/kubeadm")
 	etcdConfig = conf.ContainerLinuxConfig(`
 etcd:
+  version: 3.5.16
   advertise_client_urls: http://{PRIVATE_IPV4}:2379
   listen_client_urls: http://0.0.0.0:2379`)
 )


### PR DESCRIPTION
In this PR we remove Kubernetes tested version 1.28 which is EOL since 2 weeks and we add Kubernetes 1.31 

Tests (brightbox with Stable release):
```
=== RUN   kubeadm.v1.29.2.calico.cgroupv1.base
=== RUN   kubeadm.v1.29.2.calico.base
=== RUN   kubeadm.v1.30.1.calico.base
=== RUN   kubeadm.v1.29.2.cilium.base
=== RUN   kubeadm.v1.29.2.cilium.cgroupv1.base
=== RUN   kubeadm.v1.31.0.cilium.base
=== RUN   kubeadm.v1.30.1.cilium.base
=== RUN   kubeadm.v1.29.2.flannel.base
=== RUN   kubeadm.v1.29.2.flannel.cgroupv1.base
=== RUN   kubeadm.v1.31.0.calico.base
=== RUN   kubeadm.v1.31.0.flannel.base
=== RUN   kubeadm.v1.30.1.flannel.base
ok - kubeadm.v1.30.1.cilium.base
ok - kubeadm.v1.30.1.flannel.base
ok - kubeadm.v1.29.2.calico.cgroupv1.base
ok - kubeadm.v1.29.2.cilium.cgroupv1.base
ok - kubeadm.v1.29.2.cilium.base
ok - kubeadm.v1.29.2.flannel.base
ok - kubeadm.v1.29.2.flannel.cgroupv1.base
ok - kubeadm.v1.30.1.calico.base
ok - kubeadm.v1.31.0.flannel.base
ok - kubeadm.v1.31.0.calico.base
ok - kubeadm.v1.31.0.cilium.base
```