### PR TITLE
kola/tests: Add new cl.tpm.eventlog test for the TPM Event log

### DIFF
--- a/platform/machine/unprivqemu/flight.go
+++ b/platform/machine/unprivqemu/flight.go
@@ -81,6 +81,7 @@ func (qf *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 }
 
 func (qf *flight) Destroy() {
+	qf.BaseFlight.Destroy()
 	if qf.diskImageFile != nil {
 		qf.diskImageFile.Close()
 	}


### PR DESCRIPTION
# kola/tests: Add test for the TPM Event log

This will only work from GRUB 2.12 onwards, so restrict to 4082+. I initially wanted to add this check to the existing tpmTest function, but that wouldn't allow me to restrict the version.

flatcar/scripts#2318 should be merged first.

I also fixed a small bug while I was at it.

I think this is my first time writing Go, be nice. :stuck_out_tongue: 

## How to use

```
kola run --board=amd64-usr --platform=qemu-unpriv --qemu-firmware=flatcar_production_qemu_uefi_efi_code.fd --qemu-image=flatcar_production_qemu_uefi_image.img --debug cl.tpm.eventlog
```

## Testing done

I've run the above against an existing release image where it fails and my new [GRUB 2.12 image](https://bincache.flatcar-linux.net/images/amd64/9999.9.9+grub-2.12-1/flatcar_production_qemu_uefi_image.img) where it passes. I have also tried the Docker image from this PR against that 9999.9.9+grub-2.12-1 Jenkins run. Both [amd64](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/26976/) and [arm64](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/26977/) pass.