### PR TITLE
kola: cork: Handle QCOW2 EFI firmare images and fix arm64 Secure Boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,17 @@ wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_productio
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu_image.img.sig
 
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_code.fd
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_code.fd.sig
-gpg --verify flatcar_production_qemu_uefi_efi_code.fd.sig
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2.sig
+gpg --verify flatcar_production_qemu_uefi_efi_code.qcow2.sig
 
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.fd
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.fd.sig
-gpg --verify flatcar_production_qemu_uefi_efi_vars.fd.sig
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.qcow2
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_uefi_efi_vars.qcow2.sig
+gpg --verify flatcar_production_qemu_uefi_efi_vars.qcow2.sig
 
 sudo ./bin/kola run --board amd64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p qemu \
-    --qemu-firmware flatcar_production_qemu_uefi_efi_code.fd \
-    --qemu-ovmf-vars flatcar_production_qemu_uefi_efi_vars.fd \
+    --qemu-firmware flatcar_production_qemu_uefi_efi_code.qcow2 \
+    --qemu-ovmf-vars flatcar_production_qemu_uefi_efi_vars.qcow2 \
     --qemu-image flatcar_production_qemu_image.img \
     cl.locksmith.cluster
 ```
@@ -113,12 +113,12 @@ wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_productio
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_image.img.sig
 gpg --verify flatcar_production_qemu_uefi_image.img.sig
 
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.fd
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.fd.sig
-gpg --verify flatcar_production_qemu_uefi_efi_code.fd.sig
+wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2
+wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2.sig
+gpg --verify flatcar_production_qemu_uefi_efi_code.qcow2.sig
 
 sudo ./bin/kola run --board arm64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p qemu \
-    --qemu-firmware flatcar_production_qemu_uefi_efi_code.fd \
+    --qemu-firmware flatcar_production_qemu_uefi_efi_code.qcow2 \
     --qemu-image flatcar_production_qemu_uefi_image.img \
     cl.etcd-member.discovery
 ```

--- a/cmd/cork/downloadimage.go
+++ b/cmd/cork/downloadimage.go
@@ -87,7 +87,7 @@ func (platforms *platformList) Set(value string) error {
 		"esx":       {"_vmware_ova.ova"},
 		"gce":       {"_gce.tar.gz"},
 		"qemu":      {"_image.bin.bz2"},
-		"qemu_uefi": {"_qemu_uefi_efi_code.fd", "_qemu_uefi_efi_vars.fd", "_image.bin.bz2"},
+		"qemu_uefi": {"_qemu_uefi_efi_code.qcow2", "_qemu_uefi_efi_vars.qcow2", "_image.bin.bz2"},
 	}
 
 	values := strings.Split(value, ",")

--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -56,7 +56,7 @@ var (
 
 	kolaDefaultFirmware = map[string]string{
 		"amd64-usr": "bios-256k.bin",
-		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_code.fd",
+		"arm64-usr": sdk.BuildRoot() + "/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_code.qcow2",
 	}
 
 	kolaSSHRetries = 60

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
 	"github.com/flatcar/mantle/kola/tests/util"
@@ -58,6 +59,9 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
+		// Changing the verity hash breaks Secure Boot verification, causing
+		// GRUB to error and then just sit at the menu forever.
+		SkipFunc: kola.SkipSecureboot,
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadUsr,
@@ -68,6 +72,9 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
+		// Changing the verity hash breaks Secure Boot verification, causing
+		// GRUB to error and then just sit at the menu forever.
+		SkipFunc: kola.SkipSecureboot,
 	})
 }
 

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -372,9 +372,22 @@ func CreateQEMUCommand(board, uuid, firmware, ovmfVars, consolePath, confPath, d
 		"-device", "virtio-rng-pci,rng=rng0",
 	)
 	if ovmfVars != "" {
+		var fwFormat, varsFormat string
+
+		if strings.HasSuffix(firmware, ".qcow2") {
+			fwFormat = "qcow2"
+		} else {
+			fwFormat = "raw"
+		}
+		if strings.HasSuffix(ovmfVars, ".qcow2") {
+			varsFormat = "qcow2"
+		} else {
+			varsFormat = "raw"
+		}
+
 		qmCmd = append(qmCmd,
-			"-drive", fmt.Sprintf("if=pflash,unit=0,file=%v,format=raw,readonly=on", firmware),
-			"-drive", fmt.Sprintf("if=pflash,unit=1,file=%v,format=raw", ovmfVars),
+			"-drive", fmt.Sprintf("if=pflash,unit=0,file=%v,format=%v,readonly=on", firmware, fwFormat),
+			"-drive", fmt.Sprintf("if=pflash,unit=1,file=%v,format=%v", ovmfVars, varsFormat),
 		)
 		if enableSecureboot {
 			// When OVMF is built for X64 with SMM enabled S3 (suspend/resume)

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -389,7 +389,7 @@ func CreateQEMUCommand(board, uuid, firmware, ovmfVars, consolePath, confPath, d
 			"-drive", fmt.Sprintf("if=pflash,unit=0,file=%v,format=%v,readonly=on", firmware, fwFormat),
 			"-drive", fmt.Sprintf("if=pflash,unit=1,file=%v,format=%v", ovmfVars, varsFormat),
 		)
-		if enableSecureboot {
+		if enableSecureboot && board == "amd64-usr" {
 			// When OVMF is built for X64 with SMM enabled S3 (suspend/resume)
 			// must be disabled. This is required for secure boot and not very
 			// well documented. The flag comes from here:


### PR DESCRIPTION
# Handle QCOW2 EFI firmare images and fix Secure Boot

Forthcoming Flatcar releases will use QCOW2 instead of raw .fd images.

Only pass SMM-related arguments to QEMU for amd64-usr. EDK2 doesn't have SMM for arm64 yet and these arguments break it when Secure Boot is enabled.

Skip tests that change the verity hash when Secure Boot is enabled. Changing the verity hash breaks Secure Boot verification, causing GRUB to error and then just sit at the menu forever. It's not clear why these tests worked before we applied the Red Hat patches to GRUB, but it's now behaving as it should.

## How to use

Run tests against one of the new Flatcar Secure Boot builds.

## Testing done

Jenkins without qemu_uefi_secure is [all green](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/1772/cldsv/). I'm running qemu_uefi_secure now.