### PR TITLE
cgroupv1: set Linux cmd arg SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 to w…

### DIFF
--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -25,6 +25,11 @@ func init() {
       "contents": { "source": "data:," },
       "mode": 420
     }]
+  },
+  "kernelArguments": {
+    "shouldExist": [
+      "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1"
+    ]
   }
 }`)
 


### PR DESCRIPTION
…ork with systemd >= v256

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
