### PR TITLE
Revert "kola/tests: Skip tests that change the verity hash when SB is enabled"

### DIFF
--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -21,7 +21,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/flatcar/mantle/kola"
 	"github.com/flatcar/mantle/kola/cluster"
 	"github.com/flatcar/mantle/kola/register"
 	"github.com/flatcar/mantle/kola/tests/util"
@@ -59,9 +58,6 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
-		// Changing the verity hash breaks Secure Boot verification, causing
-		// GRUB to error and then just sit at the menu forever.
-		SkipFunc: kola.SkipSecureboot,
 	})
 	register.Register(&register.Test{
 		Run:         RecoverBadUsr,
@@ -72,9 +68,6 @@ func init() {
 		Distros:     []string{"cl"},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
-		// Changing the verity hash breaks Secure Boot verification, causing
-		// GRUB to error and then just sit at the menu forever.
-		SkipFunc: kola.SkipSecureboot,
 	})
 }
 


### PR DESCRIPTION
This reverts commit b583d18ffac499ddbcbcd7aa4b3da02903d19a9b. I misunderstood what these tests do. Booting is supposed to fail after changing the verity hash, but then it is supposed to successfully fall back to the other partition. The tests were failing due one of Red Hat's GRUB patches. We have now fixed this.