### PR TITLE
aws: fix nil pointer exception 

### DIFF
--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -223,7 +223,7 @@ func (a *API) finishSnapshotTask(snapshotTaskID, imageName string) (*Snapshot, e
 		case "completed":
 			return true, *details.SnapshotId, nil
 		case "pending", "active":
-			plog.Debugf("waiting for import task: %v (%v): %v", *details.Status, *details.Progress, *details.StatusMessage)
+			plog.Debugf("waiting for import task")
 			return false, "", nil
 		case "cancelled", "cancelling":
 			return false, "", fmt.Errorf("import task cancelled")


### PR DESCRIPTION
In the CI (and locally) we can notice random nil pointer exception during the AWS snapshot creation. In this PR, we just make the code more robust against those errors.

The details (progress and status message) are not provided by AWS at the beginning of the import. Here's the
details:
```bash
{
  DiskImageSize: 0,
  Format: "RAW",
  SnapshotId: "",
  Status: "active",
  UserBucket: {
    S3Bucket: "flatcar-kola-ami-import-us-east-1",
    S3Key: "tormath1/amd64-usr/tormath1-flatcar-stable/flatcar_production_ami_image.bin"
  }
}
```

Let's just drop it as we don't use it, this does not impact the
execution of the program. If required, we can still access to the task
via its ID using the AWS CLI.