### PR TITLE
cgroupv1: do not run tests for version >= 4179

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"math"
 	"strings"
 	"text/template"
 	"time"
@@ -146,10 +147,12 @@ func init() {
 				testParams["Release"] = version
 
 				cgroupSuffix := ""
-				var major int64 = 0
+				var majorMinVersion int64 = 0
+				var majorEndVersion int64 = math.MaxInt64
 				if testParams["cgroupv1"].(bool) {
 					cgroupSuffix = ".cgroupv1"
-					major = 3140
+					majorMinVersion = 3140
+					majorEndVersion = 4179
 				}
 
 				if CNI == "flannel" {
@@ -160,8 +163,8 @@ func init() {
 					mmv := (int64)(mmvi.(int))
 					// Careful, so we don't lower
 					// the min version too much.
-					if mmv > major {
-						major = mmv
+					if mmv > majorMinVersion {
+						majorMinVersion = mmv
 					}
 				}
 
@@ -174,7 +177,8 @@ func init() {
 					Run: func(c cluster.TestCluster) {
 						kubeadmBaseTest(c, testParams)
 					},
-					MinVersion: semver.Version{Major: major},
+					MinVersion: semver.Version{Major: majorMinVersion},
+					EndVersion: semver.Version{Major: majorEndVersion},
 					Flags:      flags,
 				})
 			}

--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -38,7 +38,7 @@ func init() {
 		},
 		Distros:    []string{"cl"},
 		MinVersion: semver.Version{Major: 3033},
-		EndVersion: semver.Version{Major: 4152},
+		EndVersion: semver.Version{Major: 4179},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 	})

--- a/kola/tests/misc/cgroup1.go
+++ b/kola/tests/misc/cgroup1.go
@@ -38,6 +38,7 @@ func init() {
 		},
 		Distros:    []string{"cl"},
 		MinVersion: semver.Version{Major: 3033},
+		EndVersion: semver.Version{Major: 4152},
 		// This test is normally not related to the cloud environment
 		Platforms: []string{"qemu", "qemu-unpriv"},
 	})


### PR DESCRIPTION
Flatcar with systemd >= 256 does not support cgroupv1 anymore.

See: https://github.com/flatcar/scripts/pull/2145

