### PR TITLE
test/nfs: lift qemu restriction

### DIFF
--- a/kola/tests/misc/nfs.go
+++ b/kola/tests/misc/nfs.go
@@ -57,8 +57,6 @@ func init() {
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
 		ExcludePlatforms: []string{"azure"},
-		// This test is normally not related to the cloud environment
-		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 	// TODO: enable FCOS when FCCT exists
 	register.Register(&register.Test{
@@ -70,8 +68,6 @@ func init() {
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
 		ExcludePlatforms: []string{"azure"},
-		// This test is normally not related to the cloud environment
-		Platforms: []string{"qemu", "qemu-unpriv"},
 	})
 }
 


### PR DESCRIPTION
this test uses network and private IP so it makes sense to enable it on cloud providers.

Tested on OpenStack / Brightbox:
```
$ cat _kola_temp/brightbox-latest/test.tap
1..2
ok - linux.nfs.v3
ok - linux.nfs.v4
```