### PR TITLE
Revert ".github: Update docker/build-push-action to v6"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true


### PR DESCRIPTION
This reverts commit 6859cfff42184e7d090c2bb58ef2afe7fbcefde4.

Let's see if it fixes ARM64 build issue. 