### PR TITLE
hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN bash -c 'cd /usr/src/mantle && ./build ; mv bin bin-amd64 ; CGO_ENABLED=0 GO
 
 # See comment above about golang:1.22-bookworm why debian:bookworm is set here
 FROM docker.io/library/debian:bookworm
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y apt-transport-https awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo swtpm
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y python-is-python3 python3
+# Work around using deprecated stuff?
+RUN sed -i -e "s/import imp; print(imp.get_magic())/import importlib.util; print(importlib.util.MAGIC_NUMBER)/" -e "s/import imp; print(imp.get_tag()/import sys; print(sys.implementation.cache_tag)/" /usr/share/python3/debpython/interpreter.py
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y apt-transport-https awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo swtpm
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-cli -y
 COPY --from=builder-amd64 /usr/src/mantle/bin-amd64 /usr/local/bin-amd64


### PR DESCRIPTION
This kinda does two things - patches the debian code to stop using deprecated stuff, but also separates installation of python and the rest of the packages into two steps. Maybe that helps?