### PR TITLE
Container image: use up-to-date azure-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,21 @@ FROM docker.io/library/debian:bookworm
 RUN apt-get update && apt-get upgrade -y
 
 # Run apt-get in the loop - recently installing python packages likes to fail…
-RUN for i in $(seq 1 5); do if apt-get --fix-broken install --no-install-recommends -y apt-transport-https awscli azure-cli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq lbzip2 nftables ovmf python-is-python3 python3 qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 qemu-utils seabios sqlite3 sudo swtpm; then echo "succeeded at ${i}"; break; elif test $i -eq 5; then echo "fail at ${i}!"; exit 1; fi; done
+RUN for i in $(seq 1 5); do \
+    if apt-get --fix-broken install --no-install-recommends -y \
+        apt-transport-https awscli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq \
+        lbzip2 nftables ovmf python-is-python3 python3 python3-pip qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 \
+        qemu-utils seabios sqlite3 sudo swtpm; then \
+            echo "succeeded at ${i}"; \
+            break; \
+    elif test $i -eq 5; then \
+        echo "fail at ${i}!"; \
+        exit 1; \
+    fi; \
+  done
+
+# Install azure-cli from Microsoft package repos as Debian ships a very outdated version
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # from https://cloud.google.com/storage/docs/gsutil_install#deb
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y


### PR DESCRIPTION
The azure-cli shipped with upstream Debian is hopelessly outdated and fails to perform basic tasks like launching VMs because it tries to talk to outdated APIs.

This change uses Microsoft's az-cli from MS Debian repositories, following https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-1-install-with-one-command.

