### PR TITLE
fix ore azure segfault

### DIFF
--- a/cmd/ore/azure/azure.go
+++ b/cmd/ore/azure/azure.go
@@ -30,7 +30,8 @@ var (
 		Short: "azure image and vm utilities",
 	}
 
-	azureLocation string
+	azureLocation              string
+	azureResourceGroupBasename string
 
 	api *azure.API
 )
@@ -39,13 +40,15 @@ func init() {
 	cli.WrapPreRun(Azure, preauth)
 
 	Azure.PersistentFlags().StringVar(&azureLocation, "azure-location", "westus", "Azure location (default \"westus\")")
+	Azure.PersistentFlags().StringVar(&azureResourceGroupBasename, "azure-resource-group-basename", "kola-cluster", "Prefix used for creating new resource groups")
 }
 
 func preauth(cmd *cobra.Command, args []string) error {
 	plog.Printf("Creating Azure API...")
 
 	a, err := azure.New(&azure.Options{
-		Location: azureLocation,
+		Location:              azureLocation,
+		ResourceGroupBasename: azureResourceGroupBasename,
 	})
 	if err != nil {
 		plog.Fatalf("Failed to create Azure API: %v", err)

--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -144,6 +144,10 @@ func New(opts *Options) (*API, error) {
 		return nil, fmt.Errorf("ResourceGroup must match AvailabilitySet")
 	}
 
+	if opts.ResourceGroupBasename == "" {
+		return nil, fmt.Errorf("ResourceGroupBasename must be set")
+	}
+
 	api := &API{
 		cloudConfig: config,
 		creds:       creds,


### PR DESCRIPTION
Missing ResourceGroupBasename in `ore` caused `ore` to have to process all rgs, also those missing the tags mantle expects. Ensure `ore azure gc` processes rgs that start with `kola-cluster` by default.