### PR TITLE
platform/azure: Provide default for ResourceGroupBasename

### DIFF
--- a/platform/api/azure/api.go
+++ b/platform/api/azure/api.go
@@ -144,10 +144,6 @@ func New(opts *Options) (*API, error) {
 		return nil, fmt.Errorf("ResourceGroup must match AvailabilitySet")
 	}
 
-	if opts.ResourceGroupBasename == "" {
-		return nil, fmt.Errorf("ResourceGroupBasename must be set")
-	}
-
 	api := &API{
 		cloudConfig: config,
 		creds:       creds,
@@ -161,6 +157,13 @@ func New(opts *Options) (*API, error) {
 	}
 
 	return api, nil
+}
+
+func (a *API) ResourceGroupBasename() string {
+	if a.Opts.ResourceGroupBasename != "" {
+		return a.Opts.ResourceGroupBasename
+	}
+	return "kola-cluster"
 }
 
 func (a *API) SetupClients() error {
@@ -298,7 +301,7 @@ func (a *API) GC(gracePeriod time.Duration) error {
 	}
 
 	for _, l := range listGroups {
-		if strings.HasPrefix(*l.Name, a.Opts.ResourceGroupBasename) {
+		if strings.HasPrefix(*l.Name, a.ResourceGroupBasename()) {
 			createdAt := *l.Tags["createdAt"]
 			timeCreated, err := time.Parse(time.RFC3339, createdAt)
 			if err != nil {

--- a/platform/machine/azure/flight.go
+++ b/platform/machine/azure/flight.go
@@ -95,7 +95,7 @@ func NewFlight(opts *azure.Options) (platform.Flight, error) {
 		blobName := imageName + ".vhd"
 		container := "temp"
 
-		af.ImageResourceGroup, err = af.Api.CreateResourceGroup(af.Api.Opts.ResourceGroupBasename + "-image")
+		af.ImageResourceGroup, err = af.Api.CreateResourceGroup(af.Api.ResourceGroupBasename() + "-image")
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 		ac.ResourceGroup = af.ImageResourceGroup
 		ac.Network = af.Network
 	} else {
-		ac.ResourceGroup, err = af.Api.CreateResourceGroup(af.Api.Opts.ResourceGroupBasename)
+		ac.ResourceGroup, err = af.Api.CreateResourceGroup(af.Api.ResourceGroupBasename())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Yet another follow-up for https://github.com/flatcar/mantle/pull/594 and https://github.com/flatcar/mantle/pull/588.

Plume prune/release/prerelease also fail. So rewire things to have a default value for resource group basename.