### PR TITLE
akamai/gc: filter out public images

### DIFF
--- a/platform/api/akamai/instance.go
+++ b/platform/api/akamai/instance.go
@@ -172,6 +172,10 @@ func (a *API) GC(ctx context.Context, gracePeriod time.Duration) error {
 	}
 
 	for _, image := range images {
+		if image.IsPublic {
+			continue
+		}
+
 		if image.Created.After(threshold) {
 			continue
 		}


### PR DESCRIPTION
for unknown reasons, public images are listed by the API even if we filter on specific tags.
Let's ignore public images.

---
Before:
```
$ ore akamai --akamai-token $(pass microsoft/linode/api-token) gc --duration 1s
2025-05-05 15:04:37.495984 I | platform/api/akamai: listing instances with filter: {"tags":"mantle"}
2025-05-05 15:04:37.883624 I | platform/api/akamai: deleting instance: 76430023
2025-05-05 15:04:37.883661 I | platform/api/akamai: deleting instance: 76430081
2025-05-05 15:04:37.883667 I | platform/api/akamai: deleting instance: 76430135
2025-05-05 15:04:38.198189 I | platform/api/akamai: deleting image: private/31848862
2025-05-05 15:04:38.198207 I | platform/api/akamai: deleting image: linode/almalinux8
2025-05-05 15:04:38.198215 I | platform/api/akamai: deleting image: linode/almalinux9
2025-05-05 15:04:38.198221 I | platform/api/akamai: deleting image: linode/alpine3.18
2025-05-05 15:04:38.198230 I | platform/api/akamai: deleting image: linode/alpine3.19
2025-05-05 15:04:38.198236 I | platform/api/akamai: deleting image: linode/alpine3.20
2025-05-05 15:04:38.198249 I | platform/api/akamai: deleting image: linode/arch
2025-05-05 15:04:38.198254 I | platform/api/akamai: deleting image: linode/centos-stream9
2025-05-05 15:04:38.198260 I | platform/api/akamai: deleting image: linode/debian11
2025-05-05 15:04:38.198265 I | platform/api/akamai: deleting image: linode/debian12
2025-05-05 15:04:38.198270 I | platform/api/akamai: deleting image: linode/fedora40
2025-05-05 15:04:38.198275 I | platform/api/akamai: deleting image: linode/fedora41
2025-05-05 15:04:38.198279 I | platform/api/akamai: deleting image: linode/gentoo
2025-05-05 15:04:38.198285 I | platform/api/akamai: deleting image: linode/kali
2025-05-05 15:04:38.198290 I | platform/api/akamai: deleting image: linode/debian12-kube-v1.29.7
2025-05-05 15:04:38.198295 I | platform/api/akamai: deleting image: linode/debian12-kube-v1.30.3
2025-05-05 15:04:38.198303 I | platform/api/akamai: deleting image: linode/debian12-kube-v1.31.0
2025-05-05 15:04:38.198309 I | platform/api/akamai: deleting image: linode/debian12-kube-v1.32.1
2025-05-05 15:04:38.198315 I | platform/api/akamai: deleting image: linode/debian12-kube-v1.33.0
2025-05-05 15:04:38.198320 I | platform/api/akamai: deleting image: linode/opensuse15.6
2025-05-05 15:04:38.198325 I | platform/api/akamai: deleting image: linode/rocky8
2025-05-05 15:04:38.198331 I | platform/api/akamai: deleting image: linode/rocky9
2025-05-05 15:04:38.198336 I | platform/api/akamai: deleting image: linode/slackware15.0
2025-05-05 15:04:38.198339 I | platform/api/akamai: deleting image: linode/ubuntu20.04
2025-05-05 15:04:38.198342 I | platform/api/akamai: deleting image: linode/ubuntu22.04
2025-05-05 15:04:38.198345 I | platform/api/akamai: deleting image: linode/ubuntu24.04
2025-05-05 15:04:38.198351 I | platform/api/akamai: deleting image: linode/ubuntu24.10
2025-05-05 15:04:38.198356 I | platform/api/akamai: deleting image: linode/alpine3.17
2025-05-05 15:04:38.198361 I | platform/api/akamai: deleting image: linode/fedora39
2025-05-05 15:04:38.198365 I | platform/api/akamai: deleting image: linode/opensuse15.5
2025-05-05 15:04:38.198368 I | platform/api/akamai: deleting image: linode/ubuntu16.04lts
2025-05-05 15:04:38.198373 I | platform/api/akamai: deleting image: linode/ubuntu18.04
````
After:
```
$ ore akamai --akamai-token $(pass microsoft/linode/api-token) gc --duration 1s
2025-05-05 15:14:31.946724 I | platform/api/akamai: listing instances with filter: {"tags":"mantle"}
2025-05-05 15:14:32.355212 I | platform/api/akamai: deleting instance: 76430023
2025-05-05 15:14:32.355230 I | platform/api/akamai: deleting instance: 76430081
2025-05-05 15:14:32.355237 I | platform/api/akamai: deleting instance: 76430135
2025-05-05 15:14:32.557126 I | platform/api/akamai: deleting image: private/31848862
```