### PR TITLE
kola/nvidia: Fix nvidia-smi path

### DIFF
--- a/kola/tests/misc/nvidia.go
+++ b/kola/tests/misc/nvidia.go
@@ -194,9 +194,9 @@ func verifyNvidiaSysextInstallationImpl(c cluster.TestCluster, sysextMode bool) 
 	if err := waitForNvidiaDriver(&c, &m); err != nil {
 		c.Fatal(err)
 	}
-	nvidiaSmiPath := "/usr/bin/nvidia-smi"
+	nvidiaSmiPath := "/opt/bin/nvidia-smi"
 	if sysextMode {
-		nvidiaSmiPath = "/opt/bin/nvidia-smi"
+		nvidiaSmiPath = "/usr/bin/nvidia-smi"
 	}
 	out := c.MustSSH(m, nvidiaSmiPath)
 	c.Logf("nvidia-smi: %s", out)


### PR DESCRIPTION
# Fix nvidia-smi path

`nvidia-smi` path is swapped for sysext vs. non-sysext mode in the test

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
