### PR TITLE
.github: add dependabot base configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      # run once a week, by default on Monday
+      interval: weekly
+


### PR DESCRIPTION
It seems that Dependabot was active only for Security updates. Let's run it on a weekly basis to update all dependencies. This can help to follow vendor dependencies upgrade (e.g AWS: https://github.com/flatcar/Flatcar/issues/1339)