### PR TITLE
test/nftables: fix JSON query

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -312,5 +312,5 @@ func firewall(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// We test that the ruleset has been created using iptables or nftables.
 	// This would return an error if the ruleset is not created.
-	c.AssertCmdOutputContains(m, `sudo nft --json list ruleset | jq '.nftables.[] | select(.chain) | .chain.policy'`, "accept")
+	c.AssertCmdOutputContains(m, `sudo nft --json list ruleset | jq '.nftables.[] | select(.rule) | .rule.expr[0].match.right'`, "80")
 }


### PR DESCRIPTION
Between two different versions of nftables, the JSON schema is a bit different: it works with 1.1.1 but not with 0.9.9.

```diff
diff --git a/alpha.json b/main.json
index 2afd1b4..13ab971 100644
--- a/alpha.json
+++ b/main.json
@@ -2,8 +2,8 @@
   "nftables": [
     {
       "metainfo": {
-        "version": "0.9.9",
-        "release_name": "Prudence Pimpleton",
+        "version": "1.1.1",
+        "release_name": "Commodore Bullmoose #2",
         "json_schema_version": 1
       }
     },
@@ -19,7 +19,35 @@
         "family": "ip",
         "table": "filter",
         "name": "INPUT",
-        "handle": 1
+        "handle": 1,
+        "type": "filter",
+        "hook": "input",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip",
+        "table": "filter",
+        "name": "FORWARD",
+        "handle": 2,
+        "type": "filter",
+        "hook": "forward",
+        "prio": 0,
+        "policy": "accept"
+      }
+    },
+    {
+      "chain": {
+        "family": "ip",
+        "table": "filter",
+        "name": "OUTPUT",
+        "handle": 3,
+        "type": "filter",
+        "hook": "output",
+        "prio": 0,
+        "policy": "accept"
       }
     },
     {
@@ -52,22 +80,6 @@
           }
         ]
       }
-    },
-    {
-      "chain": {
-        "family": "ip",
-        "table": "filter",
-        "name": "FORWARD",
-        "handle": 2
-      }
-    },
-    {
-      "chain": {
-        "family": "ip",
-        "table": "filter",
-        "name": "OUTPUT",
-        "handle": 3
-      }
     }
   ]
 }
```

So let's make the Json query more precise. Tested on LTS 4081. (Note: the `.rule.expr[]` seems to be always sorted in the same way, so we can rely on the position `0`)  