### PR TITLE
test/nftables: adjust query for LTS-3510

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -312,5 +312,5 @@ func firewall(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// We test that the ruleset has been created using iptables or nftables.
 	// This would return an error if the ruleset is not created.
-	c.AssertCmdOutputContains(m, `sudo nft --json list ruleset | jq '.nftables.[] | select(.rule) | .rule.expr[0].match.right'`, "80")
+	c.AssertCmdOutputContains(m, `sudo nft --json list ruleset | jq '.nftables[] | select(.rule) | .rule.expr[0].match.right'`, "80")
 }


### PR DESCRIPTION
`jq` version of LTS 3510 do not like the `.foo.[]` but the `.foo[]` syntax.

Which seems to be the correct one [documented](https://jqlang.org/manual/#array-object-value-iterator)

## Testing done

Tested with LTS 3510 and the on-going Alpha release.
