### PR TITLE
kola/tests/misc/verity: /boot will only be readable by root so use sudo

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -60,7 +60,7 @@ func VerityVerify(c cluster.TestCluster) {
 	rootOffset := getKernelVerityHashOffset(c)
 
 	// extract verity hash from kernel
-	ddcmd := fmt.Sprintf("dd if=/boot/flatcar/vmlinuz-a skip=%d count=64 bs=1 status=none", rootOffset)
+	ddcmd := fmt.Sprintf("sudo dd if=/boot/flatcar/vmlinuz-a skip=%d count=64 bs=1 status=none", rootOffset)
 	hash := c.MustSSH(m, ddcmd)
 
 	// find /usr dev


### PR DESCRIPTION
# kola: /boot will only be readable by root so use sudo

Otherwise `dd` can't read the kernel image.

## How to use

Run CI with the change from flatcar/init#113.

## Testing done

With the other change, [CI has passed](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/36707/cldsv/).