### PR TITLE
azure: Fetch console log from failed provisioning

### DIFF
--- a/platform/api/azure/instance.go
+++ b/platform/api/azure/instance.go
@@ -36,6 +36,7 @@ type Machine struct {
 	PrivateIPAddress string
 	InterfaceName    string
 	PublicIPName     string
+	CreateError      error
 }
 
 // InstanceOptions contains optional parameters for instance creation
@@ -254,8 +255,7 @@ func (a *API) CreateInstance(name, sshkey, resourceGroup string, userdata *conf.
 	}
 	_, err = poller.PollUntilDone(context.TODO(), nil)
 	if err != nil {
-		clean()
-		return nil, err
+		return &Machine{ID: name, CreateError: fmt.Errorf("PollUntilDone: %w", err)}, nil
 	}
 	plog.Infof("Instance %s created", name)
 

--- a/platform/machine/azure/cluster.go
+++ b/platform/machine/azure/cluster.go
@@ -96,6 +96,13 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
+	// We want to get to this point on CreateError (eg. OS Provisioning Timeout)
+	// so that the serial console output is captured for debugging.
+	if instance.CreateError != nil {
+		mach.Destroy()
+		return nil, instance.CreateError
+	}
+
 	if mach.journal, err = platform.NewJournal(mach.dir); err != nil {
 		mach.Destroy()
 		return nil, err


### PR DESCRIPTION
# azure: Fetch console log from failed provisioning

Reorder error handling, such that when a VM creation times out, we don't clean it directly but try to fetch the serial console output before deletion. This can help debug OS provisioning timeout issues.


## How to use

Provision a VM through kola with a broken ignition config, and observe that the console output ends up in the kola tmp directory.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
