### PR TITLE
kubeadm: exclude Akamai tests

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -173,7 +173,9 @@ func init() {
 					Distros: []string{"cl"},
 					// This should run on all clouds as a good end-to-end test
 					// Network config problems in qemu-unpriv
-					ExcludePlatforms: []string{"qemu-unpriv"},
+					// akamai: Tests are failing for Kubernetes because we don't use the expected disk size,
+					// so we are running out of free space.
+					ExcludePlatforms: []string{"qemu-unpriv", "akamai"},
 					Run: func(c cluster.TestCluster) {
 						kubeadmBaseTest(c, testParams)
 					},


### PR DESCRIPTION
We reached the monthly credit cap offered by Akamai by retrying too many times those failing tests.

Kubernetes tests are failing because the OS boots in a 4Gb image which is not enough to pull all kubernetes components.

There is an on-going discussion with Akamai at the moment, but we need to exclude Kubernetes tests for Akamai to avoid spending all our credits here.
