### PR TITLE
kubeadm: drop 1.31 add 1.34

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -120,7 +120,7 @@ var (
 	plog       = capnslog.NewPackageLogger("github.com/flatcar/mantle", "kola/tests/kubeadm")
 	etcdConfig = conf.ContainerLinuxConfig(`
 etcd:
-  version: 3.5.16
+  version: 3.5.22
   advertise_client_urls: http://{PRIVATE_IPV4}:2379
   listen_client_urls: http://0.0.0.0:2379`)
 )


### PR DESCRIPTION
In this PR, we drop the 1.31 Kubernetes tested version and we add the 1.34 to the tested one. See: https://endoflife.date/kubernetes

Tested with the new maximum version and the minimal version on Brightbox:
```bash
$ cat _kola_temp/brightbox-latest/test.tap
1..2
ok - kubeadm.v1.34.1.flannel.base
ok - kubeadm.v1.32.4.calico.cgroupv1.base
```