### PR TITLE
kola: Change cl.update.payload-boot-part-too-small to always fill /boot

### DIFF
--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -266,7 +266,8 @@ func payload(c cluster.TestCluster) {
 
 func payloadBootPartTooSmall(c cluster.TestCluster) {
 	addr, m := payloadPrepareMachine(nil, c)
-	c.MustSSH(m, `sudo dd if=/dev/zero of=/boot/increase_boot_part_usage bs=20M count=1`)
+	// Fill as much as we can (9999 MB)
+	c.MustSSH(m, `sudo dd if=/dev/zero of=/boot/increase_boot_part_usage bs=1M count=9999 || true`)
 	configureMachineForUpdate(c, m, addr)
 	updateMachineBootPartTooSmall(c, m)
 	tutil.AssertBootedUsr(c, m, "USR-A")


### PR DESCRIPTION
The test case used a fixed 20 MB file to fill the /boot disk so that the second kernel copy wouldn't fit. However, with the reduced minimal initrd the kernel fits four times and thus the single 20 MB file doesn't prevent the update.
Change the dd call to write as much as possible so that the disk is always filled afterwards.


## How to use/Testing done

With the image and update payload from [bincache](https://bincache.flatcar-linux.net/images/amd64/9999.9.9+kai-initrd-in-usr/) to have a case where the vmlinuz file fits multiple times.

Note that this test isn't actually executed on CI, we need to add a call in `ci-automation/vendor-testing/qemu_update.sh`