### PR TITLE
Update kubeadm config to v1beta4, whitespace cleanups, testdata generator

### DIFF
--- a/kola/tests/kubeadm/kubeadm_test.go
+++ b/kola/tests/kubeadm/kubeadm_test.go
@@ -51,20 +51,7 @@ func TestRenderTemplate(t *testing.T) {
 	})
 	t.Run("SuccessMasterScript", func(t *testing.T) {
 		for _, CNI := range CNIs {
-			res, err := render(
-				masterScript,
-				map[string]interface{}{
-					"HelmVersion":    "1.2.3",
-					"CiliumVersion":  "v0.11.1",
-					"FlannelVersion": "v0.14.0",
-					"CNI":            CNI,
-					"Endpoints":      []string{"http://1.2.3.4:2379"},
-					"Params":         "amd64",
-					"DownloadDir":    "/opt/bin",
-					"PodSubnet":      "192.168.0.0/17",
-				},
-				false,
-			)
+			res, err := render(masterScript, GetTestMasterScriptRenderParams(CNI), false)
 			require.Nil(t, err)
 			script, err := ioutil.ReadFile(fmt.Sprintf("testdata/master-%s-script.sh", CNI))
 			require.Nil(t, err)
@@ -72,22 +59,8 @@ func TestRenderTemplate(t *testing.T) {
 		}
 	})
 	t.Run("SuccessMasterConfig", func(t *testing.T) {
-		for _, arch := range []string{"amd64", "arm64"} {
-			res, err := render(
-				masterConfig,
-				map[string]interface{}{
-					"HelmVersion":      "1.2.3",
-					"CiliumVersion":    "v0.11.1",
-					"CNI":              "cilium",
-					"CiliumCLIVersion": "v0.9.0",
-					"Endpoints":        []string{"http://1.2.3.4:2379"},
-					"Arch":             arch,
-					"DownloadDir":      "/opt/bin",
-					"PodSubnet":        "192.168.0.0/17",
-					"Release":          "v1.29.2",
-				},
-				false,
-			)
+		for _, arch := range TestArchitectures {
+			res, err := render(masterConfig, GetTestMasterConfigRenderParams(arch), false)
 			require.Nil(t, err)
 			script, err := ioutil.ReadFile(fmt.Sprintf("testdata/master-cilium-%s-config.yml", arch))
 			require.Nil(t, err)

--- a/kola/tests/kubeadm/testdata.go
+++ b/kola/tests/kubeadm/testdata.go
@@ -1,0 +1,46 @@
+package kubeadm
+
+import "bytes"
+
+var (
+	TestArchitectures = []string{"amd64", "arm64"}
+)
+
+func GetTestMasterScriptRenderParams(cni string) map[string]interface{} {
+	return map[string]interface{}{
+		"HelmVersion":    "1.2.3",
+		"CiliumVersion":  "v0.11.1",
+		"FlannelVersion": "v0.14.0",
+		"CNI":            cni,
+		"Endpoints":      []string{"http://1.2.3.4:2379"},
+		"Params":         "amd64",
+		"DownloadDir":    "/opt/bin",
+		"PodSubnet":      "192.168.0.0/17",
+	}
+}
+
+func GetTestMasterConfigRenderParams(arch string) map[string]interface{} {
+	return map[string]interface{}{
+		"HelmVersion":      "1.2.3",
+		"CiliumVersion":    "v0.11.1",
+		"CNI":              "cilium",
+		"CiliumCLIVersion": "v0.9.0",
+		"Endpoints":        []string{"http://1.2.3.4:2379"},
+		"Arch":             arch,
+		"DownloadDir":      "/opt/bin",
+		"PodSubnet":        "192.168.0.0/17",
+		"Release":          "v1.29.2",
+	}
+}
+
+func GetMasterScript() string {
+	return masterScript
+}
+
+func GetMasterConfig() string {
+	return masterConfig
+}
+
+func Render(s string, p map[string]interface{}, b bool) (*bytes.Buffer, error) {
+	return render(s, p, b)
+}

--- a/kola/tests/kubeadm/testdata/kubeadmtestdatagen/README.md
+++ b/kola/tests/kubeadm/testdata/kubeadmtestdatagen/README.md
@@ -1,0 +1,5 @@
+Running `go build .` in this directory should do the trick.
+
+Call `./kubeadmtestdatagen <output directory>` to generate the data in
+the given output directory. The `<output directory>` is optional and
+defaults to current working directory.

--- a/kola/tests/kubeadm/testdata/kubeadmtestdatagen/main.go
+++ b/kola/tests/kubeadm/testdata/kubeadmtestdatagen/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/flatcar/mantle/kola/tests/kubeadm"
+)
+
+func main() {
+	outputDirectory := "."
+	if len(os.Args) > 1 {
+		outputDirectory = os.Args[1]
+	}
+	for _, CNI := range kubeadm.CNIs {
+		renderToFile(
+			fmt.Sprintf("master script for %s", CNI),
+			kubeadm.GetMasterScript(),
+			kubeadm.GetTestMasterScriptRenderParams(CNI),
+			fmt.Sprintf("%s/master-%s-script.sh", outputDirectory, CNI),
+		)
+	}
+	for _, arch := range kubeadm.TestArchitectures {
+		renderToFile(
+			fmt.Sprintf("master cilium config for %s", arch),
+			kubeadm.GetMasterConfig(),
+			kubeadm.GetTestMasterConfigRenderParams(arch),
+			fmt.Sprintf("%s/master-cilium-%s-config.yml", outputDirectory, arch),
+		)
+	}
+}
+
+func renderToFile(what, template string, parameters map[string]interface{}, outputPath string) {
+	res, err := kubeadm.Render(template, parameters, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to render %s: %v\n", what, err)
+		os.Exit(1)
+	}
+	err = os.WriteFile(outputPath, res.Bytes(), 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s for %s: %v\n", outputPath, what, err)
+		os.Exit(1)
+	}
+}

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -23,7 +23,6 @@ nodeRegistration:
   kubeletExtraArgs:
     - name: volume-plugin-dir
       value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-
 timeouts:
   controlPlaneComponentHealthCheck: 30m0s
 ---
@@ -32,9 +31,7 @@ kind: ClusterConfiguration
 etcd:
   external:
     endpoints:
-    
       - http://1.2.3.4:2379
-    
 networking:
   podSubnet: 192.168.0.0/17
 controllerManager:
@@ -58,7 +55,6 @@ spec:
   imagePath: flatcar/calico
   # Configures Calico networking.
   calicoNetwork:
-
     ipPools:
     - name: default-ipv4-ippool
       blockSize: 26

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -17,28 +17,30 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: ${cgroup}
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
-apiServer:
-  timeoutForControlPlane: 30m0s
-networking:
-  podSubnet: 192.168.0.0/17
-controllerManager:
-  extraArgs:
-    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 etcd:
   external:
     endpoints:
     
       - http://1.2.3.4:2379
     
+networking:
+  podSubnet: 192.168.0.0/17
+controllerManager:
+  extraArgs:
+    - name: flex-volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 EOF
 
 
@@ -122,18 +124,20 @@ token=$(kubeadm token create)
 certHashes=$(openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //')
 
 cat << EOF
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
-discovery:
-  bootstrapToken:
-    apiServerEndpoint: ${short_url}
-    token: ${token}
-    caCertHashes:
-    - sha256:${certHashes}
-controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+discovery:
+  bootstrapToken:
+    token: ${token}
+    apiServerEndpoint: ${short_url}
+    caCertHashes:
+    - sha256:${certHashes}
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
@@ -31,12 +31,10 @@ storage:
     - path: /opt/extensions/kubernetes/kubernetes-v1.29.2-x86-64.raw
       contents:
         source: https://extensions.flatcar.org/extensions/kubernetes-v1.29.2-x86-64.raw
-  
     - path: /opt/bin/cilium.tar.gz
       mode: 0755
       contents:
         source: https://github.com/cilium/cilium-cli/releases/download/v0.9.0/cilium-linux-amd64.tar.gz
-  
     - path: /home/core/install.sh
       mode: 0755
       contents:

--- a/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
@@ -31,12 +31,10 @@ storage:
     - path: /opt/extensions/kubernetes/kubernetes-v1.29.2-arm64.raw
       contents:
         source: https://extensions.flatcar.org/extensions/kubernetes-v1.29.2-arm64.raw
-  
     - path: /opt/bin/cilium.tar.gz
       mode: 0755
       contents:
         source: https://github.com/cilium/cilium-cli/releases/download/v0.9.0/cilium-linux-arm64.tar.gz
-  
     - path: /home/core/install.sh
       mode: 0755
       contents:

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -23,7 +23,6 @@ nodeRegistration:
   kubeletExtraArgs:
     - name: volume-plugin-dir
       value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-
 timeouts:
   controlPlaneComponentHealthCheck: 30m0s
 ---
@@ -32,9 +31,7 @@ kind: ClusterConfiguration
 etcd:
   external:
     endpoints:
-    
       - http://1.2.3.4:2379
-    
 networking:
   podSubnet: 192.168.0.0/17
 controllerManager:

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -17,28 +17,30 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: ${cgroup}
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
-apiServer:
-  timeoutForControlPlane: 30m0s
-networking:
-  podSubnet: 192.168.0.0/17
-controllerManager:
-  extraArgs:
-    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 etcd:
   external:
     endpoints:
     
       - http://1.2.3.4:2379
     
+networking:
+  podSubnet: 192.168.0.0/17
+controllerManager:
+  extraArgs:
+    - name: flex-volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 EOF
 
 
@@ -74,18 +76,20 @@ token=$(kubeadm token create)
 certHashes=$(openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //')
 
 cat << EOF
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
-discovery:
-  bootstrapToken:
-    apiServerEndpoint: ${short_url}
-    token: ${token}
-    caCertHashes:
-    - sha256:${certHashes}
-controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+discovery:
+  bootstrapToken:
+    token: ${token}
+    apiServerEndpoint: ${short_url}
+    caCertHashes:
+    - sha256:${certHashes}
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/kola/tests/kubeadm/testdata/master-flannel-script.sh
+++ b/kola/tests/kubeadm/testdata/master-flannel-script.sh
@@ -23,7 +23,6 @@ nodeRegistration:
   kubeletExtraArgs:
     - name: volume-plugin-dir
       value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-
 timeouts:
   controlPlaneComponentHealthCheck: 30m0s
 ---
@@ -32,9 +31,7 @@ kind: ClusterConfiguration
 etcd:
   external:
     endpoints:
-    
       - http://1.2.3.4:2379
-    
 networking:
   podSubnet: 192.168.0.0/17
 controllerManager:

--- a/kola/tests/kubeadm/testdata/master-flannel-script.sh
+++ b/kola/tests/kubeadm/testdata/master-flannel-script.sh
@@ -17,28 +17,30 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: ${cgroup}
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
-apiServer:
-  timeoutForControlPlane: 30m0s
-networking:
-  podSubnet: 192.168.0.0/17
-controllerManager:
-  extraArgs:
-    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 etcd:
   external:
     endpoints:
     
       - http://1.2.3.4:2379
     
+networking:
+  podSubnet: 192.168.0.0/17
+controllerManager:
+  extraArgs:
+    - name: flex-volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 EOF
 
 
@@ -68,18 +70,20 @@ token=$(kubeadm token create)
 certHashes=$(openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt | openssl rsa -pubin -outform der 2>/dev/null | openssl dgst -sha256 -hex | sed 's/^.* //')
 
 cat << EOF
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
-discovery:
-  bootstrapToken:
-    apiServerEndpoint: ${short_url}
-    token: ${token}
-    caCertHashes:
-    - sha256:${certHashes}
-controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+    - name: volume-plugin-dir
+      value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+discovery:
+  bootstrapToken:
+    token: ${token}
+    apiServerEndpoint: ${short_url}
+    caCertHashes:
+    - sha256:${certHashes}
+timeouts:
+  controlPlaneComponentHealthCheck: 30m0s
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/test
+++ b/test
@@ -41,8 +41,11 @@ fi
 echo "Checking govet..."
 go vet $pkgs
 
+# remove the internal binaries
+rm -f "${GOBIN}/kubeadmtestdatagen"
+
 echo "Running commands..."
-for cmd in ${GOBIN}/*; do
+for cmd in "${GOBIN}/"*; do
 	echo " Running $(basename ${cmd})..."
 	${cmd} --help > /dev/null
 done


### PR DESCRIPTION
Noticed a warning about some config that was deprecated in k8s 1.31, which is the oldest version of k8s we test. Since it's safe to update, I did so. But when updating testdata I noticed two things. Updating the testdata manually is annoying and there is some weird whitespace in generated yaml files. I wrote the generator for the former, and updated the templates for the latter.
