### PR TITLE
plume/containerlinux: stop publishing to Bahrain

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -69,7 +69,6 @@ var (
 				"sa-east-1",
 				"ca-central-1",
 				"ap-east-1",
-				"me-south-1",
 			},
 		},
 		"china": awsPartitionSpec{


### PR DESCRIPTION
For now, this region is not available. Let's stop trying to publish / pruning images in this region.

---

Noticed in the garbage collection:
```
13:52:35  2026-04-08T11:52:29Z prune:me-south-1: Couldn't list images in channel "alpha": couldn't list images with tag "Channel":"alpha": RequestError: send request failed
13:52:35  caused by: Post "https://ec2.me-south-1.amazonaws.com/": dial tcp 99.82.136.87:443: i/o timeout
```

(see: https://www.datacenterdynamics.com/en/news/fire-at-aws-data-center-in-bahrain-after-iranian-attack-report/)