### PR TITLE
plume/azure: update storage account name

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -173,7 +173,7 @@ func newAzureSpec(environments []azureEnvironmentSpec, container, label, categor
 	return azureSpec{
 		Offer:             "Flatcar",
 		Image:             fmt.Sprintf("flatcar_production_azure%s_image.vhd.bz2", category),
-		StorageAccount:    "flatcar",
+		StorageAccount:    "flatcar0001",
 		ResourceGroup:     "flatcar",
 		Container:         container,
 		Environments:      environments,


### PR DESCRIPTION
Azure can't handle two storage accounts with the same name, as I left for now the 'flatcar' storage account on the "old" subscription, there is a conflict.

From my understanding, this storage account is the one used to store and generate the SAS URL (needed for publishing on Azure marketplaces).

Tested here:
* https://jenkins.flatcar.org/job/container/job/garbage_collect/11/console

To be merged with:
* https://github.com/flatcar/jenkins-os/pull/430
* https://github.com/flatcar/scripts/pull/3898
