### PR TITLE
kola/harness.go: fix version detection

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -544,13 +544,14 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 	if err != nil {
 		return nil, fmt.Errorf("parsing /etc/os-release for VERSION_ID: %v: %s", err, stderr)
 	}
-	ver := strings.Split(string(out), "=")[1]
+	ver := string(out)
 
-	out, stderr, err = m.SSH("grep ^BUILD_ID= /etc/os-release")
+	out, stderr, err = m.SSH(`. /etc/os-release && echo "${BUILD_ID}"`)
 	if err != nil {
 		return nil, fmt.Errorf("parsing /etc/os-release for BUILD_ID: %v: %s", err, stderr)
 	}
-	build_id := strings.Split(string(out), "=")[1]
+	build_id := string(out)
+
 	if strings.HasPrefix(build_id, "dev-main-nightly-") || strings.HasPrefix(build_id, "dev-flatcar-master-") {
 		// "main" is a nightly build of the main branch,
 		// "flatcar-master" refers to the manifest branch where dev builds are started


### PR DESCRIPTION
This change fixes a version detection issue in `kola/harness.go` that leads to a runtime panic.

PR https://github.com/flatcar/mantle/pull/784 changed the version detection in `kola/harness.go` from parsing `os-release`file to sourcing it, to improve handling of quotes in
`os-release`::`VERSION="some-version"`.

However, the subsequent splitting of file contents was not removed:
```
ver := strings.Split(string(out), "=")[1]
```

Since the output now only contains the version string instead of the full `VERSION="..."` line, there is no `=`, and consequently there is no second field of the array returned by `split()=`.

This leads to a runtime panic:
```
github.com/flatcar/mantle/kola.getClusterSemver({0x3e2d2f8, 0xc0002b3560}, {0xc00064e0c0?, 0xc000762c30?})
        /usr/src/mantle/kola/harness.go:547 +0x7ec
github.com/flatcar/mantle/kola.RunTests({0xc00048dd48, 0x1, 0x23}, {0x386c6d9, 0x6}, {0x386afa4, 0x5}, {0x7ffe298cad02, 0x5}, {0xc00064e0c0, ...}, ...)
        /usr/src/mantle/kola/harness.go:458 +0x52a
main.runRun(0x5ab07e0?, {0xc00048dd48?, 0x1?, 0x23?})
        /usr/src/mantle/cmd/kola/kola.go:133 +0x27c
github.com/spf13/cobra.(*Command).execute(0x5ab07e0, {0xc00048db08, 0x23, 0x23})
        /usr/src/mantle/vendor/github.com/spf13/cobra/command.go:1019 +0xae7
github.com/spf13/cobra.(*Command).ExecuteC(0x5aafc60)
        /usr/src/mantle/vendor/github.com/spf13/cobra/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
        /usr/src/mantle/vendor/github.com/spf13/cobra/command.go:1071
github.com/flatcar/mantle/cli.Execute(0x5aafc60)
        /usr/src/mantle/cli/cli.go:67 +0x1db
main.main()
        /usr/src/mantle/cmd/kola/kola.go:89 +0x1a
```
