### PR TITLE
Dockerfile: Add zstd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN for i in $(seq 1 5); do \
     if apt-get --fix-broken install --no-install-recommends -y \
         apt-transport-https awscli ca-certificates curl dns-root-data dnsmasq git gnupg2 iptables jq \
         lbzip2 nftables ovmf python-is-python3 python3 python3-pip qemu-efi-aarch64 qemu-system-aarch64 qemu-system-x86 \
-        qemu-utils rclone seabios sqlite3 sudo swtpm; then \
+        qemu-utils rclone seabios sqlite3 sudo swtpm zstd; then \
             echo "succeeded at ${i}"; \
             break; \
     elif test $i -eq 5; then \


### PR DESCRIPTION
The ./run_local_tests.sh always expects this command to be existed. Add zstd to avoid the error messages

 $ ./run_local_tests.sh arm64 2 cl.cloudinit.script
 =================================
 Using Mantle docker image 'ghcr.io/flatcar/mantle:git-ca80a2eaee4cc195ae6e17f9202c1d72e729d460'
 =================================
 Running qemu_uefi tests
 git-ca80a2eaee4cc195ae6e17f9202c1d72e729d460: Pulling from flatcar/mantle
 Digest: sha256:cd37c1ba21b8051eb2632e171d4f1f9bc7e91708883575343265d3d58940d5df
 Status: Image is up to date for ghcr.io/flatcar/mantle:git-ca80a2eaee4cc195ae6e17f9202c1d72e729d460
 zstd could not be found. unpacking container image may fail.
 ++++ Running qemu_uefi.sh inside __TESTS__/qemu_uefi ++++
 ++++ qemu_uefi.sh: Using existing /work/__build__/images/images/arm64-usr/latest/flatcar_production_image.bin for testing 4593.2.0+4-gbc1fd0010d (arm64) ++++
 ++++ qemu_uefi.sh: Using existing /work/__build__/images/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_code.qcow2 ++++
 ++++ qemu_uefi.sh: Using existing /work/__build__/images/images/arm64-usr/latest/flatcar_production_qemu_uefi_efi_vars.qcow2 ++++
 === RUN   cl.cloudinit.script
 --- PASS: cl.cloudinit.script (216.26s)
 PASS, output in _kola_temp/qemu-2026-05-19-0704-13                                                                                                                                                                                     git-ca80a2eaee4cc195ae6e17f9202c1d72e729d460: Pulling from flatcar/mantle                                                                                                                                                              Digest: sha256:cd37c1ba21b8051eb2632e171d4f1f9bc7e91708883575343265d3d58940d5df
 Status: Image is up to date for ghcr.io/flatcar/mantle:git-ca80a2eaee4cc195ae6e17f9202c1d72e729d460
 zstd could not be found. unpacking container image may fail.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
