### PR TITLE
docker updates

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -733,7 +733,21 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 // the Docker security option is enabled (seccomp, selinux).
 func hasSecurityOptions(opts []string) bool {
 	for _, opt := range opts {
-		switch opt {
+		// opt = "name=seccomp,profile=builtin"
+		splitOpt := strings.Split(opt, ",")
+
+		if len(splitOpt) < 1 {
+			return false
+		}
+
+		// splitOpt = [name=seccomp profile=builtin]
+		name := strings.SplitN(splitOpt[0], "=", 2)
+		if len(name) < 2 {
+			return false
+		}
+
+		// name = [name seccomp]
+		switch name[1] {
 		case "selinux", "seccomp", "cgroupns":
 		default:
 			return false

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -656,7 +656,7 @@ func testContainerdUp(c cluster.TestCluster) {
 }
 
 func getDockerInfo(c cluster.TestCluster, m platform.Machine) (simplifiedDockerInfo, error) {
-	dockerInfoJson, err := c.SSH(m, `curl -s --unix-socket /var/run/docker.sock http://docker/v1.24/info`)
+	dockerInfoJson, err := c.SSH(m, `docker info --format json`)
 	if err != nil {
 		return simplifiedDockerInfo{}, fmt.Errorf("could not get dockerinfo: %v", err)
 	}

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -46,12 +46,10 @@ type simplifiedDockerInfo struct {
 		Path string `json:"path"`
 	}
 	ContainerdCommit struct {
-		ID       string
-		Expected string
+		ID string
 	}
 	RuncCommit struct {
-		ID       string
-		Expected string
+		ID string
 	}
 	SecurityOptions []string
 }
@@ -650,7 +648,7 @@ func testContainerdUp(c cluster.TestCluster) {
 		c.Fatal(err)
 	}
 
-	if info.ContainerdCommit.ID != info.ContainerdCommit.Expected {
+	if info.ContainerdCommit.ID == "" {
 		c.Fatalf("Docker could not find containerd")
 	}
 }
@@ -710,14 +708,6 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 
 	if info.CgroupDriver != "cgroupfs" && info.CgroupDriver != "systemd" {
 		c.Errorf("unexpected cgroup driver %v", info.CgroupDriver)
-	}
-
-	if info.ContainerdCommit.ID != info.ContainerdCommit.Expected {
-		c.Errorf("commit mismatch for containerd: %v != %v", info.ContainerdCommit.Expected, info.ContainerdCommit.ID)
-	}
-
-	if info.RuncCommit.ID != info.RuncCommit.Expected {
-		c.Errorf("commit mismatch for runc: %v != %v", info.RuncCommit.Expected, info.RuncCommit.ID)
 	}
 
 	if runcInfo, ok := info.Runtimes["runc"]; ok {

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -683,11 +683,17 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 	// Canonicalize info
 	sort.Strings(info.SecurityOptions)
 
-	// Because we prefer overlay2/overlay for different docker versions, figure
+	expectedOverlayDriver := "overlayfs"
+
+	// Because we prefer overlayfs/overlay2 for different docker versions, figure
 	// out the correct driver to be testing for based on our docker version.
-	expectedOverlayDriver := "overlay2"
-	if strings.HasPrefix(info.ServerVersion, "1.12.") || strings.HasPrefix(info.ServerVersion, "17.04.") {
-		expectedOverlayDriver = "overlay"
+	sv, err := semver.NewVersion(info.ServerVersion)
+	if err != nil {
+		c.Errorf("failed to parse Docker server version: %v", err)
+	}
+
+	if sv.LessThan(semver.Version{Major: 29}) {
+		expectedOverlayDriver = "overlay2"
 	}
 
 	expectedFsDriverMap := map[string]string{


### PR DESCRIPTION
Four commits:

* docker: get info using CLI directly

We could use 'the /info' endpoint (without the version) but it's
deprecated to use it without version[^1]:
```
If you omit the version-prefix, the current version of the API is used.
For example, calling /info is the same as calling /v1.55/info.
Using the API without a version-prefix is deprecated
and will be removed in a future release.
```

[^1]: https://docs.docker.com/reference/api/engine/version/v1.55/#section/Versioning


* docker: update security options parsing

Since years we use a versioned API to get the info, in the meantime the
API evolves to return Security Options with a key=value coma separated
string list. (Why using JSON when we can do that?)

* docker: remove "Expected" commit ID for container runtimes

This is not provided anymore.

* docker: support both overlayfs and overlay2

    * overlay2: Docker < 29
    * overlayfs: Docker >= 29
    * overlay: not shipped anymore in Flatcar
---

I checked and version of Docker in LTS, Alpha and the weekly-update are returning quite the same thing for the "docker info".

CI: 
* Weekly update: https://jenkins.flatcar.org/job/container/job/test_dispatcher/419/cldsv/
* Current LTS: https://jenkins.flatcar.org/job/container/job/test/1701/console