### PR TITLE
support Ignition 3.4.0 and Butane Flatcar 1.1.0

### DIFF
--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -38,6 +38,8 @@ import (
 	v32types "github.com/coreos/ignition/v2/config/v3_2/types"
 	v33 "github.com/coreos/ignition/v2/config/v3_3"
 	v33types "github.com/coreos/ignition/v2/config/v3_3/types"
+	v34 "github.com/coreos/ignition/v2/config/v3_4"
+	v34types "github.com/coreos/ignition/v2/config/v3_4/types"
 	ign3validate "github.com/coreos/ignition/v2/config/validate"
 	"github.com/coreos/pkg/capnslog"
 	ct "github.com/flatcar/container-linux-config-transpiler/config"
@@ -95,6 +97,7 @@ type Conf struct {
 	ignitionV31   *v31types.Config
 	ignitionV32   *v32types.Config
 	ignitionV33   *v33types.Config
+	ignitionV34   *v34types.Config
 	cloudconfig   *cci.CloudConfig
 	script        string
 	multipartMime *MultipartUserdata
@@ -319,6 +322,15 @@ func (u *UserData) Render(ctPlatform string) (*Conf, error) {
 			return err
 		}
 
+		ignc34, report34, err := v34.Parse([]byte(u.data))
+		if err == nil {
+			c.ignitionV34 = &ignc34
+			return nil
+		} else if err != ign3err.ErrUnknownVersion {
+			plog.Errorf("invalid userdata: %v", report34)
+			return err
+		}
+
 		// give up
 		return err
 	}
@@ -434,6 +446,9 @@ func (c *Conf) String() string {
 	} else if c.ignitionV33 != nil {
 		buf, _ := json.Marshal(c.ignitionV33)
 		return string(buf)
+	} else if c.ignitionV34 != nil {
+		buf, _ := json.Marshal(c.ignitionV34)
+		return string(buf)
 	} else if c.cloudconfig != nil {
 		return c.cloudconfig.String()
 	} else if c.script != "" {
@@ -465,6 +480,11 @@ func (c *Conf) MergeV32(newConfig v32types.Config) {
 func (c *Conf) MergeV33(newConfig v33types.Config) {
 	mergeConfig := v33.Merge(*c.ignitionV33, newConfig)
 	c.ignitionV33 = &mergeConfig
+}
+
+func (c *Conf) MergeV34(newConfig v34types.Config) {
+	mergeConfig := v34.Merge(*c.ignitionV34, newConfig)
+	c.ignitionV34 = &mergeConfig
 }
 
 func (c *Conf) ValidConfig() bool {
@@ -500,6 +520,8 @@ func (c *Conf) getIgnitionValidateValue() reflect.Value {
 		return reflect.ValueOf(c.ignitionV32)
 	} else if c.ignitionV33 != nil {
 		return reflect.ValueOf(c.ignitionV33)
+	} else if c.ignitionV34 != nil {
+		return reflect.ValueOf(c.ignitionV34)
 	}
 	return reflect.ValueOf(nil)
 }
@@ -678,6 +700,32 @@ func (c *Conf) addFileV33(path, filesystem, contents string, mode int) {
 	}
 	c.MergeV33(newConfig)
 }
+
+func (c *Conf) addFileV34(path, filesystem, contents string, mode int) {
+	source := dataurl.EncodeBytes([]byte(contents))
+	newConfig := v34types.Config{
+		Ignition: v34types.Ignition{
+			Version: "3.4.0",
+		},
+		Storage: v34types.Storage{
+			Files: []v34types.File{
+				{
+					Node: v34types.Node{
+						Path:      path,
+						Overwrite: &[]bool{true}[0],
+					},
+					FileEmbedded1: v34types.FileEmbedded1{
+						Contents: v34types.Resource{
+							Source: &source,
+						},
+						Mode: &mode,
+					},
+				},
+			},
+		},
+	}
+	c.MergeV34(newConfig)
+}
 func (c *Conf) addFileV1(path, filesystem, contents string, mode int) {
 	file := v1types.File{
 		Path:     v1types.Path(path),
@@ -747,7 +795,9 @@ func (c *Conf) addFileMultipartMime(path, filesystem, contents string, mode int)
 }
 
 func (c *Conf) AddFile(path, filesystem, contents string, mode int) {
-	if c.ignitionV33 != nil {
+	if c.ignitionV34 != nil {
+		c.addFileV34(path, filesystem, contents, mode)
+	} else if c.ignitionV33 != nil {
 		c.addFileV33(path, filesystem, contents, mode)
 	} else if c.ignitionV32 != nil {
 		c.addFileV32(path, filesystem, contents, mode)
@@ -888,6 +938,24 @@ func (c *Conf) addSystemdUnitV33(name, contents string, enable bool) {
 	c.MergeV33(newConfig)
 }
 
+func (c *Conf) addSystemdUnitV34(name, contents string, enable bool) {
+	newConfig := v34types.Config{
+		Ignition: v34types.Ignition{
+			Version: "3.4.0",
+		},
+		Systemd: v34types.Systemd{
+			Units: []v34types.Unit{
+				{
+					Name:     name,
+					Contents: &contents,
+					Enabled:  &enable,
+				},
+			},
+		},
+	}
+	c.MergeV34(newConfig)
+}
+
 func (c *Conf) addSystemdUnitCloudConfig(name, contents string, enable bool) {
 	c.cloudconfig.CoreOS.Units = append(c.cloudconfig.CoreOS.Units, cci.Unit{
 		Name:    name,
@@ -915,6 +983,8 @@ func (c *Conf) AddSystemdUnit(name, contents string, enable bool) {
 		c.addSystemdUnitV32(name, contents, enable)
 	} else if c.ignitionV33 != nil {
 		c.addSystemdUnitV33(name, contents, enable)
+	} else if c.ignitionV34 != nil {
+		c.addSystemdUnitV34(name, contents, enable)
 	} else if c.cloudconfig != nil {
 		c.addSystemdUnitCloudConfig(name, contents, enable)
 	}
@@ -1118,6 +1188,28 @@ func (c *Conf) addSystemdDropinV33(service, name, contents string) {
 	c.MergeV33(newConfig)
 }
 
+func (c *Conf) addSystemdDropinV34(service, name, contents string) {
+	newConfig := v34types.Config{
+		Ignition: v34types.Ignition{
+			Version: "3.4.0",
+		},
+		Systemd: v34types.Systemd{
+			Units: []v34types.Unit{
+				{
+					Name: service,
+					Dropins: []v34types.Dropin{
+						{
+							Name:     name,
+							Contents: &contents,
+						},
+					},
+				},
+			},
+		},
+	}
+	c.MergeV34(newConfig)
+}
+
 func (c *Conf) addSystemdDropinCloudConfig(service, name, contents string) {
 	for i, unit := range c.cloudconfig.CoreOS.Units {
 		if unit.Name == service {
@@ -1159,6 +1251,8 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 		c.addSystemdDropinV32(service, name, contents)
 	} else if c.ignitionV33 != nil {
 		c.addSystemdDropinV33(service, name, contents)
+	} else if c.ignitionV34 != nil {
+		c.addSystemdDropinV34(service, name, contents)
 	} else if c.cloudconfig != nil {
 		c.addSystemdDropinCloudConfig(service, name, contents)
 	}
@@ -1332,6 +1426,27 @@ func (c *Conf) copyKeysIgnitionV33(keys []*agent.Key) {
 	c.MergeV33(newConfig)
 }
 
+func (c *Conf) copyKeysIgnitionV34(keys []*agent.Key) {
+	var keyObjs []v34types.SSHAuthorizedKey
+	for _, key := range keys {
+		keyObjs = append(keyObjs, v34types.SSHAuthorizedKey(key.String()))
+	}
+	newConfig := v34types.Config{
+		Ignition: v34types.Ignition{
+			Version: "3.4.0",
+		},
+		Passwd: v34types.Passwd{
+			Users: []v34types.PasswdUser{
+				{
+					Name:              c.user,
+					SSHAuthorizedKeys: keyObjs,
+				},
+			},
+		},
+	}
+	c.MergeV34(newConfig)
+}
+
 func (c *Conf) copyKeysCloudConfig(keys []*agent.Key) {
 	c.cloudconfig.SSHAuthorizedKeys = append(c.cloudconfig.SSHAuthorizedKeys, keysToStrings(keys)...)
 }
@@ -1383,6 +1498,8 @@ func (c *Conf) CopyKeys(keys []*agent.Key) {
 		c.copyKeysIgnitionV32(keys)
 	} else if c.ignitionV33 != nil {
 		c.copyKeysIgnitionV33(keys)
+	} else if c.ignitionV34 != nil {
+		c.copyKeysIgnitionV34(keys)
 	} else if c.cloudconfig != nil {
 		c.copyKeysCloudConfig(keys)
 	} else if c.script != "" {
@@ -1405,7 +1522,7 @@ func keysToStrings(keys []*agent.Key) (keyStrs []string) {
 // Returns false in the case of empty configs as on most platforms,
 // this will default back to cloudconfig
 func (c *Conf) IsIgnition() bool {
-	return c.ignitionV1 != nil || c.ignitionV2 != nil || c.ignitionV21 != nil || c.ignitionV22 != nil || c.ignitionV23 != nil || c.ignitionV3 != nil || c.ignitionV31 != nil || c.ignitionV32 != nil || c.ignitionV33 != nil
+	return c.ignitionV1 != nil || c.ignitionV2 != nil || c.ignitionV21 != nil || c.ignitionV22 != nil || c.ignitionV23 != nil || c.ignitionV3 != nil || c.ignitionV31 != nil || c.ignitionV32 != nil || c.ignitionV33 != nil || c.ignitionV34 != nil
 }
 
 func (c *Conf) IsEmpty() bool {
@@ -1431,6 +1548,8 @@ func (c *Conf) AddUserToGroups(user string, groups []string) error {
 		c.addUserToGroupsV32(user, groups)
 	} else if c.ignitionV33 != nil {
 		c.addUserToGroupsV33(user, groups)
+	} else if c.ignitionV34 != nil {
+		c.addUserToGroupsV34(user, groups)
 	} else {
 		err = fmt.Errorf("missing addUserToGroups implementation for this config type")
 	}
@@ -1524,4 +1643,26 @@ func (c *Conf) addUserToGroupsV33(user string, groups []string) {
 		},
 	}
 	c.MergeV33(newConfig)
+}
+
+func (c *Conf) addUserToGroupsV34(user string, groups []string) {
+	g := []v34types.Group{}
+	for _, group := range groups {
+		g = append(g, v34types.Group(group))
+	}
+
+	newConfig := v34types.Config{
+		Ignition: v34types.Ignition{
+			Version: "3.4.0",
+		},
+		Passwd: v34types.Passwd{
+			Users: []v34types.PasswdUser{
+				{
+					Name:   user,
+					Groups: g,
+				},
+			},
+		},
+	}
+	c.MergeV34(newConfig)
 }

--- a/platform/conf/conf_test.go
+++ b/platform/conf/conf_test.go
@@ -43,9 +43,11 @@ func TestConfCopyKey(t *testing.T) {
 		Ignition(`{ "ignition": { "version": "3.1.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.2.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.3.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.4.0" } }`),
 		Ignition(`{ "ignitionVersion": 1 }`),
 		CloudConfig("#cloud-config"),
 		Butane("variant: flatcar\nversion: 1.0.0"),
+		Butane("variant: flatcar\nversion: 1.1.0"),
 	}
 
 	for i, tt := range tests {
@@ -108,7 +110,15 @@ func TestConfAddUserToGroups(t *testing.T) {
 			nil,
 		},
 		{
+			Ignition(`{ "ignition": { "version": "3.4.0" } }`),
+			nil,
+		},
+		{
 			Butane("variant: flatcar\nversion: 1.0.0"),
+			nil,
+		},
+		{
+			Butane("variant: flatcar\nversion: 1.1.0"),
 			nil,
 		},
 	}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_4/config.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_4/config.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3_4
+
+import (
+	"github.com/coreos/ignition/v2/config/merge"
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
+	prev "github.com/coreos/ignition/v2/config/v3_3"
+	"github.com/coreos/ignition/v2/config/v3_4/translate"
+	"github.com/coreos/ignition/v2/config/v3_4/types"
+	"github.com/coreos/ignition/v2/config/validate"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/coreos/vcontext/report"
+)
+
+func Merge(parent, child types.Config) types.Config {
+	res, _ := merge.MergeStructTranscribe(parent, child)
+	return res.(types.Config)
+}
+
+// Parse parses the raw config into a types.Config struct and generates a report of any
+// errors, warnings, info, and deprecations it encountered
+func Parse(rawConfig []byte) (types.Config, report.Report, error) {
+	if len(rawConfig) == 0 {
+		return types.Config{}, report.Report{}, errors.ErrEmpty
+	}
+
+	var config types.Config
+	if rpt, err := util.HandleParseErrors(rawConfig, &config); err != nil {
+		return types.Config{}, rpt, err
+	}
+
+	version, err := semver.NewVersion(config.Ignition.Version)
+
+	if err != nil || *version != types.MaxVersion {
+		return types.Config{}, report.Report{}, errors.ErrUnknownVersion
+	}
+
+	rpt := validate.ValidateWithContext(config, rawConfig)
+	if rpt.IsFatal() {
+		return types.Config{}, rpt, errors.ErrInvalid
+	}
+
+	return config, rpt, nil
+}
+
+// ParseCompatibleVersion parses the raw config of version 3.4.0 or
+// lesser into a 3.4 types.Config struct and generates a report of any errors,
+// warnings, info, and deprecations it encountered
+func ParseCompatibleVersion(raw []byte) (types.Config, report.Report, error) {
+	version, rpt, err := util.GetConfigVersion(raw)
+	if err != nil {
+		return types.Config{}, rpt, err
+	}
+
+	if version == types.MaxVersion {
+		return Parse(raw)
+	}
+	prevCfg, r, err := prev.ParseCompatibleVersion(raw)
+	if err != nil {
+		return types.Config{}, r, err
+	}
+	return translate.Translate(prevCfg), r, nil
+}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_4/translate/translate.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_4/translate/translate.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate
+
+import (
+	"github.com/coreos/ignition/v2/config/translate"
+	old_types "github.com/coreos/ignition/v2/config/v3_3/types"
+	"github.com/coreos/ignition/v2/config/v3_4/types"
+)
+
+func translateIgnition(old old_types.Ignition) (ret types.Ignition) {
+	// use a new translator so we don't recurse infinitely
+	translate.NewTranslator().Translate(&old, &ret)
+	ret.Version = types.MaxVersion.String()
+	return
+}
+
+func translateLuks(old old_types.Luks) (ret types.Luks) {
+	tr := translate.NewTranslator()
+	tr.AddCustomTranslator(translateTang)
+	tr.Translate(&old.Clevis, &ret.Clevis)
+	tr.Translate(&old.Device, &ret.Device)
+	tr.Translate(&old.KeyFile, &ret.KeyFile)
+	tr.Translate(&old.Label, &ret.Label)
+	tr.Translate(&old.Name, &ret.Name)
+	tr.Translate(&old.Options, &ret.Options)
+	tr.Translate(&old.UUID, &ret.UUID)
+	tr.Translate(&old.WipeVolume, &ret.WipeVolume)
+	return
+}
+
+func translateTang(old old_types.Tang) (ret types.Tang) {
+	tr := translate.NewTranslator()
+	tr.Translate(&old.Thumbprint, &ret.Thumbprint)
+	tr.Translate(&old.URL, &ret.URL)
+	return
+}
+
+func Translate(old old_types.Config) (ret types.Config) {
+	tr := translate.NewTranslator()
+	tr.AddCustomTranslator(translateIgnition)
+	tr.AddCustomTranslator(translateLuks)
+	tr.Translate(&old, &ret)
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -335,6 +335,8 @@ github.com/coreos/ignition/v2/config/v3_2/types
 github.com/coreos/ignition/v2/config/v3_3
 github.com/coreos/ignition/v2/config/v3_3/translate
 github.com/coreos/ignition/v2/config/v3_3/types
+github.com/coreos/ignition/v2/config/v3_4
+github.com/coreos/ignition/v2/config/v3_4/translate
 github.com/coreos/ignition/v2/config/v3_4/types
 github.com/coreos/ignition/v2/config/v3_5/types
 github.com/coreos/ignition/v2/config/v3_6/types


### PR DESCRIPTION
# platform/conf: support Ignition 3.4.0 and Butane Flatcar 1.1.0

This wires up Ignition spec 3.4.0 in `platform/conf`, which also unblocks Butane
`variant: flatcar` / `version: 1.1.0` (it transpiles down to Ignition 3.4.0).

The deps were already current (butane v0.29.0, ignition/v2 v2.26.0) — the only
gap was that `conf.go` still handled Ignition versions up to 3.3 only, so 3.4.0
configs fell through to "give up" and never rendered. This adds a v3_4 branch
everywhere v3_3 already exists: parsing, merge, `String()`, validation, and the
file / unit / dropin / ssh-key / groups helpers. It follows the same pattern as
the existing versions, nothing else changed.

Closes flatcar/Flatcar#1000

## How to use

This is an internal change to how mantle parses config, so there's nothing to
run

## Testing done

Compile checks:

$ go build ./platform/conf/
$ GOOS=linux go vet ./platform/conf/
(both clean, no output)

Ran the conf tests in a linux container (golang:1.25):

$ go test ./platform/conf/ -run "TestConfCopyKey|TestConfAddUserToGroups" -v
=== RUN   TestConfCopyKey
W | platform/conf: parsing Container Linux config: warning: Configuration is empty
--- PASS: TestConfCopyKey (0.03s)
=== RUN   TestConfAddUserToGroups
--- PASS: TestConfAddUserToGroups (0.00s)
PASS
ok  	github.com/flatcar/mantle/platform/conf	0.042s

