### PR TITLE
platform/conf: fix systemd dropin panic on ignition 3.1

### DIFF
--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -1154,7 +1154,7 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 	} else if c.ignitionV3 != nil {
 		c.addSystemdDropinV3(service, name, contents)
 	} else if c.ignitionV31 != nil {
-		c.addSystemdDropinV3(service, name, contents)
+		c.addSystemdDropinV31(service, name, contents)
 	} else if c.ignitionV32 != nil {
 		c.addSystemdDropinV32(service, name, contents)
 	} else if c.ignitionV33 != nil {

--- a/platform/conf/conf_test.go
+++ b/platform/conf/conf_test.go
@@ -128,3 +128,31 @@ func TestConfAddUserToGroups(t *testing.T) {
 		}
 	}
 }
+
+func TestConfAddSystemdUnitDropin(t *testing.T) {
+	tests := []*UserData{
+		Ignition(`{ "ignition": { "version": "3.0.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.1.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.2.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.3.0" } }`),
+		Butane("variant: flatcar\nversion: 1.0.0"),
+	}
+
+	for i, tt := range tests {
+		conf, err := tt.Render("")
+		if err != nil {
+			t.Errorf("failed to parse config %d: %v", i, err)
+			continue
+		}
+
+		conf.AddSystemdUnitDropin("test.service", "10-test.conf", "[Service]\nExecStart=/bin/true")
+
+		str := conf.String()
+
+		if !strings.Contains(str, "test.service") ||
+			!strings.Contains(str, "10-test.conf") ||
+			!strings.Contains(str, "ExecStart=/bin/true") {
+			t.Errorf("systemd dropin not found in config %d: %s", i, str)
+		}
+	}
+}


### PR DESCRIPTION
# platform/conf: fix a nil-pointer panic when adding a systemd dropin to an Ignition 3.1 config

`AddSystemdUnitDropin` dispatches to a per-version helper based on which
Ignition config is set. The `c.ignitionV31 != nil` branch was calling
`addSystemdDropinV3` instead of `addSystemdDropinV31` a copy-paste slip.

For a 3.1.0 config, `c.ignitionV3` is nil, so the mistakenly-called
`addSystemdDropinV3` runs `MergeV3`, which does `v3.Merge(*c.ignitionV3, ...)`
and dereferences that nil pointer. The result is a hard panic every time
`AddSystemdUnitDropin` is called on an Ignition 3.1 config. Every other version
in the dispatcher calls its matching helper; only 3.1 was wrong.

The fix points the branch at `addSystemdDropinV31`. I also added a
`TestConfAddSystemdUnitDropin` regression test that exercises the dropin path
for Ignition 3.0–3.3 and Butane flatcar 1.0.0 — it panics on the old code and
passes on the fix.

## How to use

This is an internal fix to how mantle builds config, so there's nothing to run
on a live machine. To validate:

1. Look at the one-line change in `AddSystemdUnitDropin` the 3.1 branch now
   calls `addSystemdDropinV31`, matching every other version.
2. Run the `platform/conf` tests in a Linux environment (the package doesn't
   build on non-Linux): `go test ./platform/conf/ -run TestConfAddSystemdUnitDropin -v`
3. To see the bug the fix removes, run that same test against `main` — it
   panics with a nil-pointer dereference on the 3.1.0 case.

## Testing done

With the fix — passes:

$ go test ./platform/conf/ -run TestConfAddSystemdUnitDropin -v
=== RUN   TestConfAddSystemdUnitDropin
--- PASS: TestConfAddSystemdUnitDropin (0.00s)
PASS
ok  	github.com/flatcar/mantle/platform/conf	0.054s



Without the fix (reverting just the one-line change, keeping the new test), the
same test panics — confirming it's a real regression test:

$ go test ./platform/conf/ -run TestConfAddSystemdUnitDropin -v
=== RUN   TestConfAddSystemdUnitDropin
--- FAIL: TestConfAddSystemdUnitDropin (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference
...
conf.(*Conf).MergeV3(...)                 conf.go:451
conf.(*Conf).addSystemdDropinV3(...)      conf.go:1052
conf.(*Conf).AddSystemdUnitDropin(...)    conf.go:1157
conf.TestConfAddSystemdUnitDropin(...)    conf_test.go:148
FAIL	github.com/flatcar/mantle/platform/conf	0.013s