### PR TITLE
plume: retain more gce images

### DIFF
--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -210,6 +210,43 @@ func gceUploadImage(spec *channelSpec, api *gcloud.API, obj *gs.Object, name, de
 	return op.TargetLink
 }
 
+const (
+	// gceRetentionMonths is the age below which GCE images are always kept,
+	// regardless of the channel image limit.
+	gceRetentionMonths = 9
+	// gceMinKeptImages is the minimum number of GCE images to keep, regardless
+	// of the channel image limit.
+	gceMinKeptImages = 10
+)
+
+// gceImagesToKeep returns how many of the newest images to retain when pruning.
+// oldImages must be sorted newest-first. The result is never less than limit,
+// never less than gceMinKeptImages, and always large enough to keep every image
+// created after cutoff (the retention window). This makes sure a small channel
+// limit can't prune away recent or too many images.
+func gceImagesToKeep(oldImages []*compute.Image, limit int, cutoff time.Time) int {
+	keep := limit
+	if keep < gceMinKeptImages {
+		keep = gceMinKeptImages
+	}
+	recent := 0
+	for _, image := range oldImages {
+		stamp, err := time.Parse(time.RFC3339, image.CreationTimestamp)
+		if err != nil {
+			// The sort in doGCE already fails on unparseable timestamps; treat
+			// them as old here so retention only ever errs towards keeping more.
+			continue
+		}
+		if stamp.After(cutoff) {
+			recent++
+		}
+	}
+	if keep < recent {
+		keep = recent
+	}
+	return keep
+}
+
 func doGCE(ctx context.Context, client *http.Client, src *storage.Bucket, spec *channelSpec) {
 	if spec.GCE.Project == "" || spec.GCE.Image == "" {
 		plog.Notice("GCE image creation disabled.")
@@ -351,9 +388,10 @@ func doGCE(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 		pendings = append(pendings, pending)
 	}
 
-	if spec.GCE.Limit > 0 && len(oldImages) > spec.GCE.Limit {
-		plog.Noticef("Pruning %d GCE images.", len(oldImages)-spec.GCE.Limit)
-		for _, old := range oldImages[spec.GCE.Limit:] {
+	keep := gceImagesToKeep(oldImages, spec.GCE.Limit, date.AddDate(0, -gceRetentionMonths, 0))
+	if spec.GCE.Limit > 0 && len(oldImages) > keep {
+		plog.Noticef("Pruning %d GCE images.", len(oldImages)-keep)
+		for _, old := range oldImages[keep:] {
 			plog.Noticef("Deleting old image %s", old.Name)
 			pending, err := api.DeleteImage(old.Name)
 			if err != nil {

--- a/cmd/plume/release_test.go
+++ b/cmd/plume/release_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Flatcar Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+func TestGceImagesToKeep(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cutoff := now.AddDate(0, -gceRetentionMonths, 0)
+
+	// build returns images aged the given number of months, newest first.
+	build := func(monthsOld ...int) []*compute.Image {
+		imgs := make([]*compute.Image, len(monthsOld))
+		for i, m := range monthsOld {
+			imgs[i] = &compute.Image{
+				Name:              "flatcar-stable-image",
+				CreationTimestamp: now.AddDate(0, -m, 0).Format(time.RFC3339),
+			}
+		}
+		return imgs
+	}
+
+	tests := []struct {
+		name   string
+		images []*compute.Image
+		limit  int
+		want   int
+	}{
+		{
+			// All images are older than the retention window and the channel
+			// limit is tiny, so the 10-image floor keeps things from being
+			// pruned down to almost nothing.
+			name:   "small limit still keeps at least 10",
+			images: build(10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24),
+			limit:  3,
+			want:   gceMinKeptImages,
+		},
+		{
+			// 15 images all within the last 9 months must all be kept, even
+			// though the limit is much smaller.
+			name:   "recent images are all kept",
+			images: build(0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8, 8, 8, 8),
+			limit:  3,
+			want:   15,
+		},
+		{
+			// A generous limit is honoured when it is the largest floor.
+			name:   "explicit limit wins when largest",
+			images: build(10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20),
+			limit:  20,
+			want:   20,
+		},
+		{
+			// Fewer images than the floor: the helper still reports the floor;
+			// the caller only deletes when len(images) > keep, so nothing is
+			// pruned.
+			name:   "fewer than the floor returns the floor",
+			images: build(12, 13, 14),
+			limit:  0,
+			want:   gceMinKeptImages,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gceImagesToKeep(tt.images, tt.limit, cutoff)
+			if got != tt.want {
+				t.Errorf("gceImagesToKeep() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# plume: keep all GCE images from the last 9 months and at least 10 images

plume prunes old GCE images down to `spec.GCE.Limit` newest ones and deletes the
rest. There's no age floor and no minimum, so a small channel limit can prune
away recent images or leave very few behind.

This changes the retention to keep the largest of three floors:
`max(spec.GCE.Limit, 10, number of images younger than 9 months)`. So we always
keep every image from the last 9 months, and never drop below 10 images. The
logic is pulled into a small `gceImagesToKeep` helper so it can be unit-tested
without hitting GCP. Pruning is still gated on `spec.GCE.Limit > 0`, so the
behaviour is unchanged when pruning is disabled, and the change only ever keeps
more images, never fewer.

The 9-month window and 10-image minimum are named constants
(`gceRetentionMonths`, `gceMinKeptImages`) matching the values in the issue —
happy to make them configurable (flag or channel spec) if that's preferred.

Closes flatcar/Flatcar#1263

## How to use

This changes plume's release-time GCE pruning, so there's nothing to run on a
live machine. To validate the retention logic:

    go test ./cmd/plume/ -run TestGceImagesToKeep -v

(The package doesn't build on non-Linux because of `system/exec`, so run it in a
Linux environment. `GOOS=linux go vet ./cmd/plume/` is a good quick check too.)

## Testing done

$ go test ./cmd/plume/ -run TestGceImagesToKeep -v
=== RUN   TestGceImagesToKeep
=== RUN   TestGceImagesToKeep/small_limit_still_keeps_at_least_10
=== RUN   TestGceImagesToKeep/recent_images_are_all_kept
=== RUN   TestGceImagesToKeep/explicit_limit_wins_when_largest
=== RUN   TestGceImagesToKeep/fewer_than_the_floor_returns_the_floor
--- PASS: TestGceImagesToKeep (0.00s)
--- PASS: TestGceImagesToKeep/small_limit_still_keeps_at_least_10 (0.00s)
--- PASS: TestGceImagesToKeep/recent_images_are_all_kept (0.00s)
--- PASS: TestGceImagesToKeep/explicit_limit_wins_when_largest (0.00s)
--- PASS: TestGceImagesToKeep/fewer_than_the_floor_returns_the_floor (0.00s)
PASS
ok  	github.com/flatcar/mantle/cmd/plume	0.070s



`GOOS=linux go vet ./cmd/plume/` is also clean.
