### PR TITLE
kola/devcontainer: test building an out-of-tree kernel module

### DIFF
--- a/kola/tests/devcontainer/devcontainer.go
+++ b/kola/tests/devcontainer/devcontainer.go
@@ -58,7 +58,47 @@ export FEATURES="-ipc-sandbox -network-sandbox"
 emerge-gitclone
 emerge --getbinpkg --verbose coreos-sources
 zcat /proc/config.gz >/usr/src/linux/.config
-exec make -C /usr/src/linux "-j$(nproc)" modules_prepare V=1
+make -C /usr/src/linux "-j$(nproc)" modules_prepare V=1
+
+# Verify that the developer container can actually build an out-of-tree
+# kernel module against the prepared kernel tree, not just prepare the tree.
+# See https://github.com/flatcar/Flatcar/issues/310.
+#
+# /var/tmp is used (rather than the default /tmp) because it is backed by
+# disk here, mirroring the modules_prepare workdir - under qemu we might
+# not have enough memory for a tmpfs.
+module_dir="$(mktemp -d -p /var/tmp)"
+
+cat >"${module_dir}/hello.c" <<'MODULE_EOF'
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/init.h>
+
+static int __init hello_init(void)
+{
+	pr_info("flatcar out-of-tree module test: loaded\n");
+	return 0;
+}
+
+static void __exit hello_exit(void)
+{
+	pr_info("flatcar out-of-tree module test: unloaded\n");
+}
+
+module_init(hello_init);
+module_exit(hello_exit);
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Flatcar out-of-tree kernel module build test");
+MODULE_EOF
+
+cat >"${module_dir}/Kbuild" <<'KBUILD_EOF'
+obj-m := hello.o
+KBUILD_EOF
+
+make -C /usr/src/linux "-j$(nproc)" M="${module_dir}" modules V=1
+
+# The build must have produced a loadable, non-empty module object.
+test -s "${module_dir}/hello.ko"
 `)
 
 	scriptPrologTemplate = util.TrimLeftSpace(`


### PR DESCRIPTION
The devcontainer test only ran modules_prepare, so it never actually checked
that an out-of-tree module compiles. This adds a step that builds a tiny
module against the prepared kernel tree and checks the .ko gets produced, so
a break in the module build environment shows up in CI instead of a user
hitting it.

Both the systemd-nspawn and docker variants share the same script, so both
get the coverage.

Heads up: I couldn't run kola locally, so this is only verified with go build,
go vet and gofmt. It needs a CI run to exercise the real build.

Closes flatcar/Flatcar#310
