### PR TITLE
exec: fix multicall build on non-Linux hosts

### DIFF
--- a/system/exec/multicall.go
+++ b/system/exec/multicall.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"syscall"
 )
 
 // prefix of first argument if it is defining an entrypoint to be called.
@@ -77,9 +76,7 @@ func MaybeExec() {
 func (e Entrypoint) Command(args ...string) *ExecCmd {
 	args = append([]string{entryArgPrefix + string(e)}, args...)
 	cmd := Command(exePath, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGTERM,
-	}
+	setDeathSignal(cmd)
 	return cmd
 }
 
@@ -89,8 +86,6 @@ func (e Entrypoint) Sudo(args ...string) *ExecCmd {
 	args = append([]string{"-E", "-p", "sudo password for %p: ", "--",
 		exePath, entryArgPrefix + string(e)}, args...)
 	cmd := Command("sudo", args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: syscall.SIGTERM,
-	}
+	setDeathSignal(cmd)
 	return cmd
 }

--- a/system/exec/multicall_deathsig_test.go
+++ b/system/exec/multicall_deathsig_test.go
@@ -1,0 +1,25 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import "testing"
+
+// TestSetDeathSignal exercises the OS-specific setDeathSignal split so
+// Entrypoint.Command and Entrypoint.Sudo build and run on every supported
+// host, not just Linux.
+func TestSetDeathSignal(t *testing.T) {
+	cmd := Command("true")
+	setDeathSignal(cmd)
+}

--- a/system/exec/multicall_linux.go
+++ b/system/exec/multicall_linux.go
@@ -1,0 +1,25 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import "syscall"
+
+// setDeathSignal arranges for the child process to receive SIGTERM if this
+// process dies, so multicall entrypoints do not outlive their parent.
+func setDeathSignal(cmd *ExecCmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/system/exec/multicall_other.go
+++ b/system/exec/multicall_other.go
@@ -1,0 +1,21 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package exec
+
+// setDeathSignal is a no-op on platforms that do not support Pdeathsig
+// (e.g. darwin), since multicall entrypoints only run on Linux hosts.
+func setDeathSignal(cmd *ExecCmd) {}


### PR DESCRIPTION
## Summary
- Fix `system/exec/multicall.go` compiling only on Linux due to `syscall.SysProcAttr.Pdeathsig` being a Linux-only field.

## Linked Issue
Fixes flatcar/Flatcar#2245

## What Changed
- Removed the direct `syscall.SysProcAttr{Pdeathsig: ...}` initialization from `Entrypoint.Command()` and `Entrypoint.Sudo()`.
- Added a `setDeathSignal` helper, implemented in `system/exec/multicall_linux.go` (sets `Pdeathsig` as before) and `system/exec/multicall_other.go` (no-op on non-Linux), following the existing `_linux.go` filename-based build convention already used in this package (e.g. `system/anonfile_linux.go`).
- Added `system/exec/multicall_deathsig_test.go` covering the new helper.

## Verification
- `go build -mod=vendor ./system/exec/...` — passed (previously failed with `unknown field Pdeathsig` on darwin/arm64)
- `GOOS=darwin GOARCH=arm64 go build -mod=vendor ./system/exec/...` — passed
- `GOOS=linux GOARCH=amd64 go build -mod=vendor ./system/exec/...` — passed
- `go vet ./system/exec/...` — passed
- `gofmt -l` on changed files — passed (no output)
- `staticcheck ./system/exec/...` — passed (no output)
- `go test -mod=vendor -c ./system/exec/` (compile-only, both darwin and linux/amd64) — passed
- `go test -mod=vendor -cover ./system/exec/...` — not run to completion on this darwin host: the test binary panics in an unrelated, pre-existing `init()` call to `os.Readlink("/proc/self/exe")`, which is Linux-only and out of scope for this fix. This panic is reproducible on the unmodified `main` branch as well and is unrelated to the `Pdeathsig` change.

## Scope
- Only `system/exec/multicall.go` and the two new OS-specific helper files plus their test are changed; no unrelated files were modified.
