### PR TITLE
kola: fix architecture() for qemu-unpriv

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -679,7 +679,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 // architecture returns the machine architecture of the given platform.
 func architecture(pltfrm string) string {
 	nativeArch := "amd64"
-	if pltfrm == "qemu" && QEMUOptions.Board != "" {
+	if (pltfrm == "qemu" || pltfrm == "qemu-unpriv") && QEMUOptions.Board != "" {
 		nativeArch = boardToArch(QEMUOptions.Board)
 	}
 	if pltfrm == "aws" && AWSOptions.Board != "" {

--- a/kola/harness_test.go
+++ b/kola/harness_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Flatcar Maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kola
+
+import "testing"
+
+func TestArchitecture(t *testing.T) {
+	origBoard := QEMUOptions.Board
+	defer func() { QEMUOptions.Board = origBoard }()
+
+	tests := []struct {
+		platform string
+		board    string
+		want     string
+	}{
+		{"qemu", "amd64-usr", "amd64"},
+		{"qemu", "arm64-usr", "arm64"},
+		// qemu-unpriv shares QEMUOptions with qemu, so it must resolve the
+		// board's arch the same way (regression test for the wrong-arch kolet).
+		{"qemu-unpriv", "amd64-usr", "amd64"},
+		{"qemu-unpriv", "arm64-usr", "arm64"},
+	}
+
+	for _, tt := range tests {
+		QEMUOptions.Board = tt.board
+		if got := architecture(tt.platform); got != tt.want {
+			t.Errorf("architecture(%q) with board %q = %q, want %q", tt.platform, tt.board, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
`architecture()` decides which kolet binary to upload, based on the platform's
board. It only special-cased `qemu`, so `qemu-unpriv` always resolved to
`amd64` even with an arm64 board, and the wrong-arch kolet got uploaded (fails
with "Exec format error" on arm64 qemu-unpriv native-func tests).

qemu-unpriv runs off the same `QEMUOptions` as qemu, and `FilterTests` already
treats qemu-unpriv like qemu, so this just aligns `architecture()` with that.

Adds a regression test (`TestArchitecture`) that fails on the old code and
passes on the fix.

Closes flatcar/Flatcar#2290
