### PR TITLE
kola/tests: convert simple CLC test fixtures to Butane

### DIFF
--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -40,7 +40,9 @@ func init() {
 		Name:      "docker.enable-service.torcx",
 		// Torcx was retired after release 3760.
 		EndVersion: semver.Version{Major: 3760},
-		UserData: conf.ContainerLinuxConfig(`
+		UserData: conf.Butane(`
+variant: flatcar
+version: 1.0.0
 systemd:
   units:
   - name: docker.service

--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -38,10 +38,14 @@ func init() {
 		// This test is normally not related to the cloud environment unless the OEM tools would unexpectedly listen on ports
 		Platforms: []string{"qemu", "qemu-unpriv"},
 		// be sure to notice listeners in the docker stack
-		UserData: conf.ContainerLinuxConfig(`systemd:
+		UserData: conf.Butane(`---
+variant: flatcar
+version: 1.0.0
+systemd:
   units:
     - name: docker.service
-      enabled: true`),
+      enabled: true
+`),
 		MinVersion: semver.Version{Major: 1967},
 	})
 	register.Register(&register.Test{

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -31,12 +31,16 @@ import (
 var (
 	// prevents a race where update-engine sets the boot partition back to
 	// USR-A after the test sets it to USR-B
-	disableUpdateEngine = conf.ContainerLinuxConfig(`systemd:
+	disableUpdateEngine = conf.Butane(`
+variant: flatcar
+version: 1.0.0
+systemd:
   units:
     - name: update-engine.service
       mask: true
     - name: locksmithd.service
-      mask: true`)
+      mask: true
+`)
 )
 
 func init() {


### PR DESCRIPTION
## Summary

Converts 3 straightforward `conf.ContainerLinuxConfig(...)` test fixtures to `conf.Butane(...)`, as a first step towards flatcar/Flatcar#1386 (dropping `ct`/Container Linux Config support from mantle).

- `kola/tests/misc/update.go`: `disableUpdateEngine` (used by `cl.update.reboot`, `cl.update.badverity`, `coreos.update.badusr`)
- `kola/tests/misc/network.go`: `cl.network.listeners`
- `kola/tests/docker/enable_docker.go`: `docker.enable-service.torcx`

These three were chosen because they only use CLC's `systemd.units[]` (`enabled`/`mask`), which maps 1:1 onto Butane's schema with no behavior change. `network.go` and `enable_docker.go` already had sibling tests using `conf.Butane(...)` in the same file, so these conversions follow that existing local style.

## Testing

**Static equivalence check**: rendered both the old CLC and new Butane strings through `platform/conf.UserData.Render()` (the same code path kola uses to turn test userdata into Ignition before booting a VM) and confirmed the resulting `systemd.units[]` entries are byte-identical between the two for all 3 sites only the Ignition spec version differs (2.3.0 for CLC vs 3.3.0 for Butane), which is expected.

**Live `kola run` on qemu**, each test run against an image matching its version constraints:

| Test | Image | Result |
|---|---|---|
| `cl.update.reboot` | stable 4593.2.4 | PASS |
| `cl.update.badverity` | stable 4593.2.4 | PASS |
| `coreos.update.badusr` | stable 4593.2.4 | PASS |
| `cl.network.listeners` | stable 4593.2.4 | PASS |
| `docker.enable-service.torcx` | stable 3760.2.0 | PASS |

<img width="1066" height="596" alt="Screenshot from 2026-08-05 20-18-43" src="https://github.com/user-attachments/assets/9db1abf0-6e45-4163-9fc0-7908c8c58d07" />


`docker.enable-service.torcx` is scoped `EndVersion: {Major: 3760}` (torcx was retired after that release), so it was run against 3760.2.0, the last stable release still within that bound, rather than the current image the other 4 tests used. On that build torcx still exists and Docker is a base-OS component, matching what the test expects. (For reference: forcing this test by exact name onto the current 4593.2.4 image bypassing kola's own version gate does fail there, but for an unrelated reason: modern builds ship Docker via a sysext that isn't enabled by default, confirmed via journal logs and via the sysext-era sibling test `docker.enable-service.sysext` passing cleanly on that same image.)

`go build`, `go vet`, and `gofmt` are all clean on the changed files.
