### PR TITLE
chore: replace deprecated io/ioutil with os and io functions

### DIFF
--- a/cmd/kola/console.go
+++ b/cmd/kola/console.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -61,9 +61,9 @@ func runCheckConsole(cmd *cobra.Command, args []string) {
 			if checkConsoleVerbose {
 				fmt.Printf("Reading input from %s...\n", sourceName)
 			}
-			console, err = ioutil.ReadAll(os.Stdin)
+			console, err = io.ReadAll(os.Stdin)
 		} else {
-			console, err = ioutil.ReadFile(arg)
+			console, err = os.ReadFile(arg)
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/kola/spawn.go
+++ b/cmd/kola/spawn.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,7 +89,7 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 
 	var userdata *conf.UserData
 	if spawnUserData != "" {
-		userbytes, err := ioutil.ReadFile(spawnUserData)
+		userbytes, err := os.ReadFile(spawnUserData)
 		if err != nil {
 			return fmt.Errorf("Reading userdata failed: %v", err)
 		}
@@ -166,7 +165,7 @@ func doSpawn(cmd *cobra.Command, args []string) error {
 		plog.Infof("Spawning machine...")
 		if kolaPlatform == "qemu" && spawnMachineOptions != "" {
 			var b []byte
-			b, err = ioutil.ReadFile(spawnMachineOptions)
+			b, err = os.ReadFile(spawnMachineOptions)
 			if err != nil {
 				return fmt.Errorf("Could not read machine options: %v", err)
 			}

--- a/cmd/ore/stackit/create.go
+++ b/cmd/ore/stackit/create.go
@@ -2,6 +2,7 @@ package stackit
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ore/stackit/gc.go
+++ b/cmd/ore/stackit/gc.go
@@ -2,8 +2,9 @@ package stackit
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/ore/stackit/stackit.go
+++ b/cmd/ore/stackit/stackit.go
@@ -5,11 +5,12 @@ package stackit
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/flatcar/mantle/cli"
 	"github.com/flatcar/mantle/platform/api/stackit"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (

--- a/cmd/plume/plume.go
+++ b/cmd/plume/plume.go
@@ -15,8 +15,8 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
@@ -45,7 +45,7 @@ func getGoogleClient() (*http.Client, error) {
 	}
 
 	if gceJSONKeyFile != "" {
-		if b, err := ioutil.ReadFile(gceJSONKeyFile); err == nil {
+		if b, err := os.ReadFile(gceJSONKeyFile); err == nil {
 			return auth.GoogleClientFromJSONKey(b)
 		} else {
 			return nil, err

--- a/harness/harness.go
+++ b/harness/harness.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -340,7 +339,7 @@ func (h *H) TempDir(prefix string) string {
 		h.log(err.Error())
 		h.FailNow()
 	}
-	tmp, err := ioutil.TempDir(dir, prefix)
+	tmp, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		h.log(fmt.Sprintf("Failed to create temp dir: %v", err))
 		h.FailNow()
@@ -356,7 +355,7 @@ func (h *H) TempFile(prefix string) *os.File {
 		h.log(err.Error())
 		h.FailNow()
 	}
-	tmp, err := ioutil.TempFile(dir, prefix)
+	tmp, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		h.log(fmt.Sprintf("Failed to create temp file: %v", err))
 		h.FailNow()

--- a/harness/harness_test.go
+++ b/harness/harness_test.go
@@ -18,7 +18,6 @@ package harness
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -322,7 +321,7 @@ func makeRegexp(s string) string {
 
 func TestOutputDir(t *testing.T) {
 	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
+	if dir, err := os.MkdirTemp("", ""); err != nil {
 		t.Fatal(err)
 	} else {
 		defer os.RemoveAll(dir)
@@ -358,7 +357,7 @@ func TestOutputDir(t *testing.T) {
 
 func TestSubDirs(t *testing.T) {
 	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
+	if dir, err := os.MkdirTemp("", ""); err != nil {
 		t.Fatal(err)
 	} else {
 		defer os.RemoveAll(dir)
@@ -394,7 +393,7 @@ func TestSubDirs(t *testing.T) {
 
 func TestTempDir(t *testing.T) {
 	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
+	if dir, err := os.MkdirTemp("", ""); err != nil {
 		t.Fatal(err)
 	} else {
 		defer os.RemoveAll(dir)
@@ -440,7 +439,7 @@ func TestTempDir(t *testing.T) {
 
 func TestTempFile(t *testing.T) {
 	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
+	if dir, err := os.MkdirTemp("", ""); err != nil {
 		t.Fatal(err)
 	} else {
 		defer os.RemoveAll(dir)

--- a/kola/tests/coretest/cloudinit.go
+++ b/kola/tests/coretest/cloudinit.go
@@ -3,7 +3,6 @@ package coretest
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -14,7 +13,7 @@ import (
 const cloudinitBinPath = "/usr/bin/coreos-cloudinit"
 
 func read(filename string) (string, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	return string(bytes), err
 }
 
@@ -24,7 +23,7 @@ func rmdir(path string) error {
 }
 
 func TestCloudinitCloudConfig() error {
-	workspace, err := ioutil.TempDir("", "coretest-cloudinit-")
+	workspace, err := os.MkdirTemp("", "coretest-cloudinit-")
 	if err != nil {
 		return fmt.Errorf("Failed creating workspace: %v", err)
 	}
@@ -42,7 +41,7 @@ ssh_authorized_keys:
     - %s
 `
 	configData := fmt.Sprintf(configTmpl, keyOne, keyTwo)
-	configFile, err := ioutil.TempFile(os.TempDir(), "coretest-")
+	configFile, err := os.CreateTemp(os.TempDir(), "coretest-")
 	if err != nil {
 		return fmt.Errorf("Failed creating tempfile: %v", err)
 	}
@@ -83,7 +82,7 @@ ssh_authorized_keys:
 }
 
 func TestCloudinitScript() error {
-	workspace, err := ioutil.TempDir("", "coretest-cloudinit-")
+	workspace, err := os.MkdirTemp("", "coretest-cloudinit-")
 	if err != nil {
 		return fmt.Errorf("Failed creating workspace: %v", err)
 	}
@@ -92,7 +91,7 @@ func TestCloudinitScript() error {
 	configData := `#!/bin/bash
 /bin/sleep 10
 `
-	configFile, err := ioutil.TempFile(os.TempDir(), "coretest-")
+	configFile, err := os.CreateTemp(os.TempDir(), "coretest-")
 	if err != nil {
 		return fmt.Errorf("Failed creating tempfile: %v", err)
 	}

--- a/kola/tests/coretest/helpers.go
+++ b/kola/tests/coretest/helpers.go
@@ -6,7 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -103,7 +103,7 @@ func Sha256File(fileName string) (hash string, err error) {
 		return
 	}
 
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		return
 	}
@@ -131,7 +131,7 @@ func MachineID() string {
 
 	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}

--- a/kola/tests/crio/crio.go
+++ b/kola/tests/crio/crio.go
@@ -17,7 +17,7 @@ package crio
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -205,7 +205,7 @@ func crioBaseTests(c cluster.TestCluster) {
 func generateCrioConfig(podName, imageName string, command []string) (string, string, error) {
 	fileContentsPod := fmt.Sprintf(crioPodTemplate, podName, imageName)
 
-	tmpFilePod, err := ioutil.TempFile("", podName+"Pod")
+	tmpFilePod, err := os.CreateTemp("", podName+"Pod")
 	if err != nil {
 		return "", "", err
 	}
@@ -216,7 +216,7 @@ func generateCrioConfig(podName, imageName string, command []string) (string, st
 	cmd := strings.Join(command, " ")
 	fileContentsContainer := fmt.Sprintf(crioContainerTemplate, imageName, imageName, cmd)
 
-	tmpFileContainer, err := ioutil.TempFile("", imageName+"Container")
+	tmpFileContainer, err := os.CreateTemp("", imageName+"Container")
 	if err != nil {
 		return "", "", err
 	}

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -17,10 +17,10 @@ package ignition
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -138,12 +138,12 @@ EOF
 }
 
 func ServeTLS(customFile []byte) error {
-	publicKey, err := ioutil.ReadFile("/var/tls/server.crt")
+	publicKey, err := os.ReadFile("/var/tls/server.crt")
 	if err != nil {
 		return fmt.Errorf("reading public key: %v", err)
 	}
 
-	privateKey, err := ioutil.ReadFile("/var/tls/server.key")
+	privateKey, err := os.ReadFile("/var/tls/server.key")
 	if err != nil {
 		return fmt.Errorf("reading private key: %v", err)
 	}

--- a/kola/tests/kubeadm/kubeadm_test.go
+++ b/kola/tests/kubeadm/kubeadm_test.go
@@ -17,7 +17,7 @@ package kubeadm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,7 +53,7 @@ func TestRenderTemplate(t *testing.T) {
 		for _, CNI := range CNIs {
 			res, err := render(masterScript, GetTestMasterScriptRenderParams(CNI), false)
 			require.Nil(t, err)
-			script, err := ioutil.ReadFile(fmt.Sprintf("testdata/master-%s-script.sh", CNI))
+			script, err := os.ReadFile(fmt.Sprintf("testdata/master-%s-script.sh", CNI))
 			require.Nil(t, err)
 			assert.Equal(t, string(script), res.String())
 		}
@@ -62,7 +62,7 @@ func TestRenderTemplate(t *testing.T) {
 		for _, arch := range TestArchitectures {
 			res, err := render(masterConfig, GetTestMasterConfigRenderParams(arch), false)
 			require.Nil(t, err)
-			script, err := ioutil.ReadFile(fmt.Sprintf("testdata/master-cilium-%s-config.yml", arch))
+			script, err := os.ReadFile(fmt.Sprintf("testdata/master-cilium-%s-config.yml", arch))
 			require.Nil(t, err)
 			assert.Equal(t, string(script), res.String())
 		}

--- a/network/journal/record_test.go
+++ b/network/journal/record_test.go
@@ -17,7 +17,6 @@ package journal
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func (d discardCloser) Close() error {
 }
 
 func (d discardCloser) Write(b []byte) (int, error) {
-	return ioutil.Discard.Write(b)
+	return io.Discard.Write(b)
 }
 
 // Escapes ; chars in cursor with \

--- a/network/jump.go
+++ b/network/jump.go
@@ -4,14 +4,14 @@ package network
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"golang.org/x/crypto/ssh"
 )
 
 // NewJumpDialer initializes a RetryDialer with SSH Proxy Jump.
 func NewJumpDialer(addr, user, keyfile string) (*RetryDialer, error) {
-	key, err := ioutil.ReadFile(keyfile)
+	key, err := os.ReadFile(keyfile)
 	if err != nil {
 		return nil, fmt.Errorf("reading private key: %w", err)
 	}

--- a/platform/api/aws/s3.go
+++ b/platform/api/aws/s3.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -208,7 +207,7 @@ func (a *API) UpdateBucketObjectsACL(srcBucket, prefix, policy string) error {
 
 // Downloads a file from S3 to a temporary file. This file must be closed by the caller.
 func (a *API) DownloadFile(srcBucket, srcPath string) (*os.File, error) {
-	f, err := ioutil.TempFile("", "mantle-file")
+	f, err := os.CreateTemp("", "mantle-file")
 	if err != nil {
 		return nil, err
 	}

--- a/platform/api/esx/api.go
+++ b/platform/api/esx/api.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/url"
 	"path"
@@ -309,7 +309,7 @@ func (a *API) GetConsoleOutput(name string) (string, error) {
 	}
 	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		return "", fmt.Errorf("couldn't read serial output: %v", err)
 	}

--- a/platform/api/esx/archive.go
+++ b/platform/api/esx/archive.go
@@ -19,7 +19,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -46,7 +45,7 @@ func (t *archive) readOvf(fpath string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (t *archive) readEnvelope(fpath string) (*ovf.Envelope, error) {

--- a/platform/api/gcloud/api.go
+++ b/platform/api/gcloud/api.go
@@ -17,8 +17,8 @@ package gcloud
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -74,7 +74,7 @@ func New(opts *Options) (*API, error) {
 	if opts.ServiceAuth {
 		client = auth.GoogleServiceClient()
 	} else if opts.JSONKeyFile != "" {
-		b, err := ioutil.ReadFile(opts.JSONKeyFile)
+		b, err := os.ReadFile(opts.JSONKeyFile)
 		if err != nil {
 			plog.Fatal(err)
 		}

--- a/platform/cluster.go
+++ b/platform/cluster.go
@@ -17,7 +17,7 @@ package platform
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -257,7 +257,7 @@ func (bc *BaseCluster) GetDiscoveryURL(size int) (string, error) {
 			return fmt.Errorf("Discovery service returned %q", resp.Status)
 		}
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/platform/conf/conf.go
+++ b/platform/conf/conf.go
@@ -20,7 +20,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -151,7 +151,7 @@ func Script(data string) *UserData {
 
 func decompressIfGzipped(data []byte) []byte {
 	if reader, err := gzip.NewReader(bytes.NewReader(data)); err == nil {
-		uncompressedData, err := ioutil.ReadAll(reader)
+		uncompressedData, err := io.ReadAll(reader)
 		reader.Close()
 		if err == nil {
 			return uncompressedData
@@ -506,7 +506,7 @@ func (c *Conf) getIgnitionValidateValue() reflect.Value {
 
 // WriteFile writes the userdata in Conf to a local file.
 func (c *Conf) WriteFile(name string) error {
-	return ioutil.WriteFile(name, []byte(c.String()), 0666)
+	return os.WriteFile(name, []byte(c.String()), 0666)
 }
 
 // Bytes returns the serialized userdata in Conf.

--- a/platform/journal.go
+++ b/platform/journal.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -129,7 +128,7 @@ func (j *Journal) Read() ([]byte, error) {
 		return nil, fmt.Errorf("reading journal: %v", err)
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (j *Journal) Destroy() {

--- a/platform/local/etcd.go
+++ b/platform/local/etcd.go
@@ -16,7 +16,6 @@ package local
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -62,7 +61,7 @@ func NewSimpleEtcd() (*SimpleEtcd, error) {
 		return nil, err
 	}
 
-	se.dataDir, err = ioutil.TempDir("", tempPrefix)
+	se.dataDir, err = os.MkdirTemp("", tempPrefix)
 	if err != nil {
 		se.Destroy()
 		return nil, err

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -15,7 +15,6 @@
 package qemu
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -87,7 +86,7 @@ func (m *machine) Destroy() {
 	}
 	m.journal.Destroy()
 
-	if buf, err := ioutil.ReadFile(filepath.Join(m.subDir, m.consolePath)); err == nil {
+	if buf, err := os.ReadFile(filepath.Join(m.subDir, m.consolePath)); err == nil {
 		m.console = string(buf)
 	} else {
 		plog.Errorf("Error reading console for instance %v: %v", m.ID(), err)

--- a/platform/machine/unprivqemu/cluster.go
+++ b/platform/machine/unprivqemu/cluster.go
@@ -17,7 +17,6 @@ package unprivqemu
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -244,7 +243,7 @@ func (qc *Cluster) newAddresses() (string, string, error) {
 
 // parse /proc/net/tcp to determine the port selected by QEMU
 func getAddress(pid string) (string, error) {
-	data, err := ioutil.ReadFile("/proc/net/tcp")
+	data, err := os.ReadFile("/proc/net/tcp")
 	if err != nil {
 		return "", fmt.Errorf("reading /proc/net/tcp: %v", err)
 	}
@@ -265,7 +264,7 @@ func getAddress(pid string) (string, error) {
 		}
 
 		dir := fmt.Sprintf("/proc/%s/fd/", pid)
-		fds, err := ioutil.ReadDir(dir)
+		fds, err := os.ReadDir(dir)
 		if err != nil {
 			return "", fmt.Errorf("listing %s: %v", dir, err)
 		}

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -15,7 +15,6 @@
 package unprivqemu
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -89,7 +88,7 @@ func (m *machine) Destroy() {
 	}
 	m.journal.Destroy()
 
-	if buf, err := ioutil.ReadFile(filepath.Join(m.subDir, m.consolePath)); err == nil {
+	if buf, err := os.ReadFile(filepath.Join(m.subDir, m.consolePath)); err == nil {
 		m.console = string(buf)
 	} else {
 		plog.Errorf("Error reading console for instance %v: %v", m.ID(), err)

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -17,7 +17,7 @@ package platform
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	origExec "os/exec"
 	"path"
@@ -87,7 +87,7 @@ func MakeCLDiskTemplate(inputPath string) (output *os.File, result error) {
 	}
 
 	// create mount point
-	tmpdir, err := ioutil.TempDir("", "kola-qemu-")
+	tmpdir, err := os.MkdirTemp("", "kola-qemu-")
 	if err != nil {
 		return nil, fmt.Errorf("making temporary directory: %v", err)
 	}
@@ -107,7 +107,7 @@ func MakeCLDiskTemplate(inputPath string) (output *os.File, result error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("running losetup: %v", err)
 	}
-	buf, err := ioutil.ReadAll(stdout)
+	buf, err := io.ReadAll(stdout)
 	if err != nil {
 		cmd.Wait()
 		return nil, fmt.Errorf("reading losetup output: %v", err)
@@ -288,7 +288,7 @@ func setupDisk(additionalOptions ...string) (*os.File, error) {
 }
 
 func mkpath(basedir string) (string, error) {
-	f, err := ioutil.TempFile(basedir, "mantle-qemu")
+	f, err := os.CreateTemp(basedir, "mantle-qemu")
 	if err != nil {
 		return "", err
 	}

--- a/sdk/download.go
+++ b/sdk/download.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -198,7 +197,7 @@ func DownloadSDK(urlHost, urlPath, version, verifyKeyFile, JSONKeyFile string) e
 
 	var client *http.Client = nil
 	if len(JSONKeyFile) != 0 {
-		b, err := ioutil.ReadFile(JSONKeyFile)
+		b, err := os.ReadFile(JSONKeyFile)
 		if err != nil {
 			return fmt.Errorf("reading key: %w", err)
 		}

--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -17,7 +17,6 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -171,7 +170,7 @@ func (e *enter) MountSSHAgent() error {
 		return nil
 	}
 
-	newDir, err := ioutil.TempDir(e.UserRunDir, "agent-")
+	newDir, err := os.MkdirTemp(e.UserRunDir, "agent-")
 	if err != nil {
 		return err
 	}
@@ -257,7 +256,7 @@ func (e *enter) CopyGoogleCreds() error {
 		return os.Unsetenv(jsonEnvName)
 	}
 
-	stateDir, err := ioutil.TempDir(e.UserRunDir, "google-")
+	stateDir, err := os.MkdirTemp(e.UserRunDir, "google-")
 	if err != nil {
 		return err
 	}
@@ -281,7 +280,7 @@ func (e *enter) CopyGoogleCreds() error {
 		return err
 	}
 
-	credsRaw, err := ioutil.ReadFile(jsonSrc)
+	credsRaw, err := os.ReadFile(jsonSrc)
 	if err != nil {
 		return err
 	}
@@ -327,7 +326,7 @@ func (e enter) SetupDNS() error {
 	resolv := "/etc/resolv.conf"
 	chrootResolv := filepath.Join(e.Chroot, resolv)
 	if !e.UseHostDNS {
-		return ioutil.WriteFile(chrootResolv, []byte(defaultResolv), 0644)
+		return os.WriteFile(chrootResolv, []byte(defaultResolv), 0644)
 	}
 
 	if _, err := os.Stat(resolv); err == nil {

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -17,7 +17,6 @@ package sdk
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -87,7 +86,7 @@ func RepoCache() string {
 func DefaultBoard() string {
 	defaultBoard := system.PortageArch() + "-usr"
 	cfg := filepath.Join(RepoRoot(), defaultBoardCfg)
-	board, err := ioutil.ReadFile(cfg)
+	board, err := os.ReadFile(cfg)
 	if err != nil {
 		return defaultBoard
 	}

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -17,7 +17,6 @@ package sdk
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -441,7 +440,7 @@ func VerifyFile(file, verifyKeyFile string) error {
 	if verifyKeyFile == "" {
 		key = buildbot_coreos_PubKey
 	} else {
-		b, err := ioutil.ReadFile(verifyKeyFile)
+		b, err := os.ReadFile(verifyKeyFile)
 		if err != nil {
 			return fmt.Errorf("%v: %s", err, verifyKeyFile)
 		}

--- a/sdk/version.go
+++ b/sdk/version.go
@@ -17,7 +17,6 @@ package sdk
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,14 +91,14 @@ func OSRelease(root string) (ver Versions, err error) {
 
 func SetManifestSDKVersion(version string) error {
 	versionPath := filepath.Join(RepoRoot(), ".repo", "manifests", "version.txt")
-	originalContent, err := ioutil.ReadFile(versionPath)
+	originalContent, err := os.ReadFile(versionPath)
 	if err != nil {
 		return err
 	}
 
 	re := regexp.MustCompile(`FLATCAR_SDK_VERSION=.*`)
 	newContent := re.ReplaceAll(originalContent, []byte("FLATCAR_SDK_VERSION="+version))
-	err = ioutil.WriteFile(versionPath, newContent, 0644)
+	err = os.WriteFile(versionPath, newContent, 0644)
 	if err != nil {
 		return err
 	}
@@ -140,7 +139,7 @@ func versionsFromRemoteRepoMaybeVerify(url, branch string, verify bool) (ver Ver
 		}
 	}
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return
 	}

--- a/sdk/version_test.go
+++ b/sdk/version_test.go
@@ -15,7 +15,6 @@
 package sdk
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +55,7 @@ FLATCAR_SDK_VERSION=967.0.0
 	}}}
 
 func TestVersionsFromDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,7 @@ func TestVersionsFromDir(t *testing.T) {
 
 	filename := filepath.Join(dir, "version.txt")
 	for _, data := range versionTestData {
-		err = ioutil.WriteFile(filename, []byte(data.Text), 0600)
+		err = os.WriteFile(filename, []byte(data.Text), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/system/anonfile_linux_test.go
+++ b/system/anonfile_linux_test.go
@@ -15,7 +15,6 @@
 package system
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -23,7 +22,7 @@ import (
 )
 
 func TestAnonymousFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +36,7 @@ func TestAnonymousFile(t *testing.T) {
 	}
 	defer anon.Close()
 
-	info, err := ioutil.ReadDir(tmp)
+	info, err := os.ReadDir(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +49,7 @@ func TestAnonymousFile(t *testing.T) {
 		t.Errorf("Link failed: %v", err)
 	}
 
-	info, err = ioutil.ReadDir(tmp)
+	info, err = os.ReadDir(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,19 +59,19 @@ func TestAnonymousFile(t *testing.T) {
 }
 
 func TestLinkFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
 
-	orig, err := ioutil.TempFile(tmp, "")
+	orig, err := os.CreateTemp(tmp, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer orig.Close()
 
-	info, err := ioutil.ReadDir(tmp)
+	info, err := os.ReadDir(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +108,7 @@ func TestLinkFile(t *testing.T) {
 }
 
 func TestPrivateFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +129,7 @@ func TestPrivateFile(t *testing.T) {
 	}
 	defer priv.Close()
 
-	info, err := ioutil.ReadDir(tmp)
+	info, err := os.ReadDir(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/system/copy_test.go
+++ b/system/copy_test.go
@@ -16,7 +16,7 @@ package system
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +34,7 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 		t.Fatalf("Unexpected mode: %s %s", info.Mode(), path)
 	}
 
-	newData, err := ioutil.ReadAll(file)
+	newData, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,14 +45,14 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 
 func TestCopyRegularFile(t *testing.T) {
 	data := []byte("test")
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
 
 	src := filepath.Join(tmp, "src")
-	if err := ioutil.WriteFile(src, data, 0600); err != nil {
+	if err := os.WriteFile(src, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 	checkFile(t, src, data, 0600)
@@ -75,14 +75,14 @@ func TestCopyRegularFile(t *testing.T) {
 
 func TestInstallRegularFile(t *testing.T) {
 	data := []byte("test")
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
 
 	src := filepath.Join(tmp, "src")
-	if err := ioutil.WriteFile(src, data, 0600); err != nil {
+	if err := os.WriteFile(src, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 	checkFile(t, src, data, 0600)

--- a/update/generator/bzip2_test.go
+++ b/update/generator/bzip2_test.go
@@ -17,14 +17,14 @@ package generator
 import (
 	"bytes"
 	"compress/bzip2"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/flatcar/mantle/system/exec"
 )
 
 func bunzip2(t *testing.T, z []byte) []byte {
-	b, err := ioutil.ReadAll(bzip2.NewReader(bytes.NewReader(z)))
+	b, err := io.ReadAll(bzip2.NewReader(bytes.NewReader(z)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/update/generator/full_test.go
+++ b/update/generator/full_test.go
@@ -17,7 +17,6 @@ package generator
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -155,7 +154,7 @@ func TestFullUpdateScanUnaligned(t *testing.T) {
 }
 
 func checkFullProc(t *testing.T, source, sourceHash []byte) *Procedure {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +189,7 @@ func TestFullUpdateOnes(t *testing.T) {
 	proc := checkFullProc(t, testOnes, testOnesHash)
 	defer proc.Close()
 
-	payload, err := ioutil.ReadAll(proc)
+	payload, err := io.ReadAll(proc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +201,7 @@ func TestFullUpdateRand(t *testing.T) {
 	proc := checkFullProc(t, testRand, testRandHash)
 	defer proc.Close()
 
-	payload, err := ioutil.ReadAll(proc)
+	payload, err := io.ReadAll(proc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/update/generator/generator_test.go
+++ b/update/generator/generator_test.go
@@ -16,7 +16,7 @@ package generator
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -40,7 +40,7 @@ func TestGenerateWithoutPartition(t *testing.T) {
 	g := testGenerator{t: t}
 	defer g.Destroy()
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,13 +87,13 @@ func TestGenerateOneBlockPartition(t *testing.T) {
 				},
 			},
 		},
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(testOnes)),
+		ReadCloser: io.NopCloser(bytes.NewReader(testOnes)),
 	}
 	if err := g.Partition(&proc); err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestGenerateOneBlockPartition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := ioutil.TempFile("", "")
+	out, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestGenerateOneBlockPartition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	written, err := ioutil.ReadAll(out)
+	written, err := io.ReadAll(out)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/update/metadata/update_metadata.pb.go
+++ b/update/metadata/update_metadata.pb.go
@@ -20,9 +20,13 @@ It has these top-level messages:
 */
 package metadata
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
+
+	proto "github.com/golang/protobuf/proto"
+
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/update/operation.go
+++ b/update/operation.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/flatcar/mantle/update/metadata"
@@ -61,7 +60,7 @@ func (op *Operation) Verify() error {
 		if len(op.Operation.SrcExtents) != 0 {
 			return fmt.Errorf("replace contains source extents")
 		}
-		if _, err := io.Copy(ioutil.Discard, op); err != nil {
+		if _, err := io.Copy(io.Discard, op); err != nil {
 			return err
 		}
 		if err := op.verifyHash(); err != nil {
@@ -151,7 +150,7 @@ func (op *Operation) replace(dst *os.File, src io.Reader) error {
 	if op.N != 0 {
 		if op.Operation.GetType() == metadata.InstallOperation_REPLACE_BZ {
 			plog.Warningf("Go's bzip2 left %d bytes unread!", op.N)
-			if _, err := io.Copy(ioutil.Discard, op); err != nil {
+			if _, err := io.Copy(io.Discard, op); err != nil {
 				return err
 			}
 		} else {

--- a/update/payload.go
+++ b/update/payload.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 
 	"github.com/golang/protobuf/proto"
 
@@ -152,7 +151,7 @@ func (p *Payload) VerifySignature() error {
 	}
 
 	// There shouldn't be any extra data following the signatures.
-	if n, err := io.Copy(ioutil.Discard, p); err != nil {
+	if n, err := io.Copy(io.Discard, p); err != nil {
 		return fmt.Errorf("trailing read failure: %v", err)
 	} else if n != 0 {
 		return fmt.Errorf("found %d trailing bytes", n)


### PR DESCRIPTION
# Replace deprecated io/ioutil with os and io functions

Resolves flatcar/Flatcar#2305

The `io/ioutil` package was officially deprecated in Go 1.16 in favor of the `os` and `io` packages. This PR performs a project-wide mechanical refactoring across 41 files to modernize the codebase and prevent future linter warnings as the Go toolchain evolves.

## How to use

Reviewers can validate this PR by confirming that all changes are 1:1 functional replacements (e.g., `ioutil.ReadFile` -> `os.ReadFile`). No underlying logic has been modified.

## Testing done

The refactoring was performed mechanically using standard Go AST rewrite tools (`gofmt -r`) and `goimports` to guarantee safety and correctness.

- [ ] Changelog entries added in the respective `changelog/` directory (N/A - internal code chore)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. (N/A)
