### PR TITLE
platform/api/aws: remove redundant error return from CreateTags

### DIFF
--- a/platform/api/aws/ec2.go
+++ b/platform/api/aws/ec2.go
@@ -278,7 +278,7 @@ func (a *API) CreateTags(resources []string, tags map[string]string) error {
 	if err != nil {
 		return fmt.Errorf("error creating tags: %v", err)
 	}
-	return err
+	return nil
 }
 
 // GetConsoleOutput returns the console output. Returns "", nil if no logs


### PR DESCRIPTION
# platform/api/aws: remove redundant error return from CreateTags

In `platform/api/aws/ec2.go`, the `CreateTags` function checks if the error from the API call is non-nil and returns early with a wrapped error. However, at the very end of the function, it returns `err` again instead of `nil`. This is redundant (since `err` is guaranteed to be `nil` at that point) and makes the code slightly confusing.

This PR updates the final return statement to return `nil` directly, making the intent clearer and avoiding potential bugs if code is ever added between the error check and the return statement in the future.

## How to use

Review the code diff to confirm that the logic remains functionally identical, but is clearer to read.

## Testing done

Audited the code manually and verified that the success path correctly returns a `nil` error without altering the failure path behavior.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.