### PR TITLE
kola/docker: convert docker.service symlink to upholds dependency

### DIFF
--- a/kola/tests/docker/enable_docker.go
+++ b/kola/tests/docker/enable_docker.go
@@ -65,13 +65,11 @@ systemd:
     enabled: true
 storage:
   links:
-  - path: /etc/systemd/system/multi-user.target.wants/docker.service
+  - path: /etc/systemd/system/multi-user.target.upholds/docker.service
     target: /usr/lib/systemd/system/docker.service
     hard: false
     overwrite: true
 `),
-		// TODO FIXME: Convert this to a multi-user.target.upholds/docker.service symlink
-		// after we switch to systemd-254.
 		Distros: []string{"cl"},
 	})
 }


### PR DESCRIPTION
Since the upgrade to systemd 254+, we can now use the stronger multi-user.target.upholds dependency instead of multi-user.target.wants to ensure docker.service automatically restarts if it goes down, which was the original intent of the test.

This PR resolves a longstanding `TODO FIXME` in `kola/tests/docker/enable_docker.go`. It updates the Butane configuration string inside the `docker.enable-service.sysext` test to utilize the `.upholds/` drop-in directory instead of `.wants/`. 

## How to use

Reviewers can validate this PR by running the modified Kola test and confirming that Docker successfully auto-starts on boot using the new `upholds` dependency mapping. 

## Testing done

Compiled the `kola/tests/docker` package locally to ensure there are no syntactic regressions, using `$env:GOOS="linux"; cd kola/tests/docker; go build`.

```text
$env:GOOS="linux"; cd kola/tests/docker; go build
(exit code 0)
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
