### PR TITLE
kola/tests/ignition/passwd: accept both * and ! for group passwords

### DIFF
--- a/kola/tests/ignition/passwd.go
+++ b/kola/tests/ignition/passwd.go
@@ -340,9 +340,12 @@ func testGroup(c cluster.TestCluster, m platform.Machine, tests []groupTest) {
 		} else if out != t.groupRecord {
 			c.Errorf("%q wasn't correctly created: got %q, expected %q", t.group, out, t.groupRecord)
 		}
-		if out, err := getent(c, m, "gshadow", t.group); err != nil {
+		out, err := getent(c, m, "gshadow", t.group)
+		if err != nil {
 			c.Fatal(err)
-		} else if out != t.gshadowRecord {
+		}
+		// Accept both '*' and '!' as locked passwords
+		if out != t.gshadowRecord && out != strings.Replace(t.gshadowRecord, ":*:", ":!:", 1) {
 			c.Errorf("%q wasn't correctly created: got %q, expected %q", t.group, out, t.gshadowRecord)
 		}
 	}


### PR DESCRIPTION
Both * and ! are functionally equivalent

---

With Ignition upgrade (2.26.0) we're pulling this change https://github.com/coreos/ignition/pull/2158. It impacts the `/etc/gshadow` file when no password is provided to the created group: previously Ignition was setting `*` when the password was empty, now we delegate this to `groupadd` which sets `!`

Tested with current nighlies ("old" Ignition): https://jenkins.flatcar.org/job/container/job/test/2376/
Tested with "new" Ignition: https://jenkins.flatcar.org/job/container/job/test/2374

This is a port from the upstream PR: https://github.com/coreos/coreos-assembler/pull/4387