### PR TITLE
kola/coretest: directly test update_engine DBus interface

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -134,22 +134,25 @@ func TestUpdateEngine() error {
 
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("update_engine_client", "-status")
+		c := exec.Command(
+			"gdbus", "call", "--system",
+			"--dest", "org.chromium.UpdateEngine",
+			"--object-path", "/org/chromium/UpdateEngine",
+			"--method", "org.chromium.UpdateEngineInterface.GetStatus",
+		)
 		err := c.Run()
 		errc <- err
 	}()
 
 	select {
 	case <-time.After(CmdTimeout):
-		return fmt.Errorf("update_engine_client timed out after %s.", CmdTimeout)
+		return fmt.Errorf("update_engine dbus call timed out after %s.", CmdTimeout)
 	case err := <-errc:
 		if err != nil {
-			return err
+			return fmt.Errorf("update_engine dbus call failed: %v", err)
 		}
 		return nil
 	}
-
-	// FIXME(marineam): Test DBus directly
 }
 
 func TestDockerEcho() error {


### PR DESCRIPTION
This resolves a `FIXME` in `TestUpdateEngine` by replacing the CLI wrapper execution with a direct `gdbus` call to the `org.chromium.UpdateEngine` DBus system interface. 

This natively verifies that the `update_engine` daemon is alive, successfully attached to the system bus, and capable of responding to RPC calls, which matches exactly how external controllers (like Kubernetes reboot agents) integrate with the service.

## How to use

Reviewers can validate this PR by running the internet-dependent tests and ensuring the `UpdateEngine` step successfully completes over the DBus interface:
```bash
kola run cl.internet
```

## Testing done

Executed `$env:GOOS="linux"; cd kola/tests/coretest; go build` to syntactically verify the package logic and ensure no compilation regressions occurred in the modified goroutine.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->