### PR TITLE
kubernetes: test 1.37

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -77,6 +77,19 @@ var (
 	// testConfig holds params for various kubernetes releases
 	// and the nested params are used to render script templates
 	testConfig = map[string]map[string]interface{}{
+		"v1.37.0": map[string]interface{}{
+			"HelmVersion":     "v3.17.3",
+			"MinMajorVersion": 3374,
+			// from https://github.com/flannel-io/flannel/releases
+			"FlannelVersion": "v0.26.7",
+			// from https://github.com/cilium/cilium/releases
+			"CiliumVersion": "1.12.5",
+			// from https://github.com/cilium/cilium-cli/releases
+			"CiliumCLIVersion": "v0.12.12",
+			"DownloadDir":      "/opt/bin",
+			"PodSubnet":        "192.168.0.0/17",
+			"cgroupv1":         false,
+		},
 		"v1.36.1": map[string]interface{}{
 			"HelmVersion":     "v3.17.3",
 			"MinMajorVersion": 3374,

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -103,19 +103,6 @@ var (
 			"PodSubnet":        "192.168.0.0/17",
 			"cgroupv1":         false,
 		},
-		"v1.34.4": map[string]interface{}{
-			"HelmVersion":     "v3.17.3",
-			"MinMajorVersion": 3374,
-			// from https://github.com/flannel-io/flannel/releases
-			"FlannelVersion": "v0.26.7",
-			// from https://github.com/cilium/cilium/releases
-			"CiliumVersion": "1.12.5",
-			// from https://github.com/cilium/cilium-cli/releases
-			"CiliumCLIVersion": "v0.12.12",
-			"DownloadDir":      "/opt/bin",
-			"PodSubnet":        "192.168.0.0/17",
-			"cgroupv1":         false,
-		},
 	}
 	plog       = capnslog.NewPackageLogger("github.com/flatcar/mantle", "kola/tests/kubeadm")
 	etcdConfig = conf.ContainerLinuxConfig(`
@@ -127,11 +114,11 @@ etcd:
 
 func init() {
 	testConfigCgroupV1 := map[string]map[string]interface{}{}
-	testConfigCgroupV1["v1.34.4"] = map[string]interface{}{}
-	for k, v := range testConfig["v1.34.4"] {
-		testConfigCgroupV1["v1.34.4"][k] = v
+	testConfigCgroupV1["v1.35.1"] = map[string]interface{}{}
+	for k, v := range testConfig["v1.35.1"] {
+		testConfigCgroupV1["v1.35.1"][k] = v
 	}
-	testConfigCgroupV1["v1.34.4"]["cgroupv1"] = true
+	testConfigCgroupV1["v1.35.1"]["cgroupv1"] = true
 
 	registerTests := func(config map[string]map[string]interface{}) {
 		for version, params := range config {


### PR DESCRIPTION
Kubernetes 1.37 is out, let's drop 1.34 and add 1.37 (active support for 1.34 ends today).

Tested with current Beta on Oraclecloud:
```
1..6
ok - kubeadm.v1.37.0.flannel.base
ok - kubeadm.v1.37.0.calico.base
ok - kubeadm.v1.37.0.cilium.base
ok - kubeadm.v1.35.1.flannel.cgroupv1.base
ok - kubeadm.v1.35.1.cilium.cgroupv1.base
ok - kubeadm.v1.35.1.calico.cgroupv1.base
```