### PR TITLE
lts: remove 2 tests

### DIFF
--- a/kola/tests/bpf/ig.go
+++ b/kola/tests/bpf/ig.go
@@ -26,6 +26,13 @@ func init() {
 		// Required while SELinux policy is not correctly updated to support
 		// `bpf` and `perfmon` permissions.
 		Flags: []register.Flag{register.NoEnableSelinux},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (4081) fails to run this test. Given that:
+			// 1. It's Azure only on ARM64
+			// 2. This current LTS is about to be deprecated
+			// We can just ignore this test for version < 4593 on Azure.
+			return version.LessThan(semver.Version{Major: 4593}) && platform == "azure" && arch == "arm64"
+		},
 	})
 }
 

--- a/kola/tests/ignition/ssh.go
+++ b/kola/tests/ignition/ssh.go
@@ -15,6 +15,8 @@
 package ignition
 
 import (
+	"github.com/coreos/go-semver/semver"
+
 	"github.com/flatcar/mantle/kola/register"
 	"github.com/flatcar/mantle/platform/conf"
 )
@@ -42,5 +44,9 @@ func init() {
 		UserData:         conf.Ignition(`{"ignition":{"version":"2.0.0"}}`),
 		UserDataV3:       conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
 		Distros:          []string{"cl", "fcos", "rhcos"},
+		SkipFunc: func(version semver.Version, channel, arch, platform string) bool {
+			// LTS (4081) fails to run this test. It's an issue with WAagent and we never backported the fix to LTS.
+			return version.LessThan(semver.Version{Major: 4593}) && platform == "azure"
+		},
 	})
 }


### PR DESCRIPTION
In this PR, we remove two tests for LTS. They both bring noise, exhauste resources and create the habit of seeing "failures" as normal:
* `coreos.ignition.ssh.key`: LTS (4081) fails to run this test. It's an issue with WAagent and we never backported the fix to LTS.
* `bpf.ig`: LTS (4081) fails to run this test. Given that:
    1. It's Azure only on ARM64
    2. This current LTS is about to be deprecated
 
   We can just ignore this test for version < 4593 on Azure.


---

There is a last one: `azure.nvme-friendly-naming` but it has to be solved on the `scripts` side.